### PR TITLE
Next.js 13 migration

### DIFF
--- a/features/channels/components/twitch-channel/TwitchVideoListing.tsx
+++ b/features/channels/components/twitch-channel/TwitchVideoListing.tsx
@@ -18,7 +18,6 @@ export const TwitchVideoListing = ({ videoData }: TwitchVideoListingProps) => {
             src={videoData.getThumbnailUrl(240, 135)}
             height={135}
             width={240}
-            layout="fixed"
             alt="Video thumbnail"
           />
         ) : (
@@ -26,7 +25,6 @@ export const TwitchVideoListing = ({ videoData }: TwitchVideoListingProps) => {
             src="/images/no-thumbnail.png"
             height={135}
             width={240}
-            layout="fixed"
             alt="Video thumbnail"
           />
         )}

--- a/features/channels/components/youtube-channel/YouTubeVideoListing.tsx
+++ b/features/channels/components/youtube-channel/YouTubeVideoListing.tsx
@@ -20,7 +20,6 @@ export const YouTubeVideoListing = ({
             src={videoData.snippet.thumbnails.medium.url}
             height={135}
             width={240}
-            layout="fixed"
             alt="Video thumbnail"
           />
         ) : (
@@ -28,7 +27,6 @@ export const YouTubeVideoListing = ({
             src="/images/no-thumbnail.png"
             height={135}
             width={240}
-            layout="fixed"
             alt="Video thumbnail"
           />
         )}

--- a/features/search/components/twitch-search/TwitchChannelResult.tsx
+++ b/features/search/components/twitch-search/TwitchChannelResult.tsx
@@ -19,7 +19,6 @@ export const TwitchChannelResult = ({
           height={100}
           width={100}
           className={styles.thumbnail}
-          layout="fixed"
         />
         {channelData.isLive && <span className={styles.live}>LIVE</span>}
       </div>

--- a/features/search/components/youtube-search/YouTubeChannelResult.tsx
+++ b/features/search/components/youtube-search/YouTubeChannelResult.tsx
@@ -19,7 +19,6 @@ export const YouTubeChannelResult = ({
           height={100}
           width={100}
           className={styles.thumbnail}
-          layout="fixed"
         />
       </div>
       <div className={styles.channelText}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
         "@twurple/api": "^5.2.5",
         "@twurple/auth": "^5.2.5",
         "javascript-time-ago": "^2.5.9",
-        "next": "13.0.2",
-        "react": "18.2.0",
-        "react-dom": "18.2.0",
+        "next": "^13.0.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
         "react-query": "^3.39.2"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "@twurple/api": "^5.2.5",
     "@twurple/auth": "^5.2.5",
     "javascript-time-ago": "^2.5.9",
-    "next": "13.0.2",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "next": "^13.0.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-query": "^3.39.2"
   },
   "devDependencies": {

--- a/pages/twitch-channel/[channelId].tsx
+++ b/pages/twitch-channel/[channelId].tsx
@@ -36,7 +36,6 @@ const TwitchChannel = ({ channelId }: TwitchChannelProps) => {
               alt={`${data.channelData.displayName} channel thumbnail`}
               height={100}
               width={100}
-              layout="fixed"
             />
             {data.userData.offlinePlaceholderUrl && (
               <Image
@@ -44,7 +43,6 @@ const TwitchChannel = ({ channelId }: TwitchChannelProps) => {
                 alt={`${data.channelData.displayName} channel banner`}
                 height={100}
                 width={100}
-                layout="fixed"
               />
             )}
           </div>

--- a/pages/youtube-channel/[channelId].tsx
+++ b/pages/youtube-channel/[channelId].tsx
@@ -51,7 +51,6 @@ const YouTubeChannel = ({ channelId }: YouTubeChannelProps) => {
                     alt={`${data.channelData.snippet.title} channel thumbnail`}
                     height={100}
                     width={100}
-                    layout="fixed"
                   />
                   <Image
                     src={
@@ -60,7 +59,6 @@ const YouTubeChannel = ({ channelId }: YouTubeChannelProps) => {
                     alt={`${data.channelData.snippet.title} channel banner`}
                     height={100}
                     width={100}
-                    layout="fixed"
                   />
                 </div>
                 <div>


### PR DESCRIPTION
This PR migrates to all of the relevant Next.js 13 features, which at this time is fixed to `next/link` and `next/image` adjustments. 