### PR TITLE
Query name adjustments

### DIFF
--- a/features/search/components/SearchBar.tsx
+++ b/features/search/components/SearchBar.tsx
@@ -19,7 +19,7 @@ export const SearchBar = () => {
     // Router.push returns a promise, but this is an odd choice, and at this stage there is no intention of awaiting this promise for handling. The void keyword indicates this choice
     void router.push({
       pathname: `/${platform}/search`,
-      query: { searchQuery },
+      query: { term: searchQuery },
     });
   };
 

--- a/features/search/components/__tests__/SearchBar.test.tsx
+++ b/features/search/components/__tests__/SearchBar.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { SearchBar } from "features/search";
 import userEvent from "@testing-library/user-event";
 import { useRouter } from "next/router";
@@ -100,7 +100,7 @@ describe("Search bar and button UI states", () => {
 });
 
 describe("Search bar functionality", () => {
-  it("routes to search page with correct searchQuery when Twitch search btn is pressed", async () => {
+  it("routes to search page with correct search term when Twitch search btn is pressed", async () => {
     const mockRouter = {
       push: jest.fn(),
       pathname: "",
@@ -116,11 +116,11 @@ describe("Search bar functionality", () => {
     await userEvent.click(btn);
     expect(mockRouter.push).toHaveBeenCalledWith({
       pathname: "/twitch/search",
-      query: { searchQuery: "hello" },
+      query: { term: "hello" },
     });
   });
 
-  it("routes to search page with correct searchQuery when YouTube search btn is pressed", async () => {
+  it("routes to search page with correct search term when YouTube search btn is pressed", async () => {
     const mockRouter = {
       push: jest.fn(),
       pathname: "",
@@ -136,7 +136,7 @@ describe("Search bar functionality", () => {
     await userEvent.click(youtubeButton);
     expect(mockRouter.push).toHaveBeenCalledWith({
       pathname: "/youtube/search",
-      query: { searchQuery: "hello" },
+      query: { term: "hello" },
     });
   });
 
@@ -154,7 +154,7 @@ describe("Search bar functionality", () => {
     await userEvent.keyboard("[Enter]");
     expect(mockRouter.push).toHaveBeenCalledWith({
       pathname: "/twitch/search",
-      query: { searchQuery: "hello" },
+      query: { term: "hello" },
     });
   });
 

--- a/features/search/hooks/useYoutubeSearch.ts
+++ b/features/search/hooks/useYoutubeSearch.ts
@@ -14,7 +14,7 @@ export const useYouTubeSearch = (
   let enableApi = false;
 
   // ! Default this API call to NEVER occur in development unless manually set here. This API call cost 100 units of quota, so if you burn through 100 calls, every YouTube API feature is locked for 24 hours.
-  if (process.env.NODE_ENV === "development") {
+  if (process.env.NODE_ENV === "production") {
     enableApi = true;
   } else {
     enableApi = false;

--- a/pages/twitch/search.tsx
+++ b/pages/twitch/search.tsx
@@ -13,7 +13,7 @@ const Search = () => {
 
   return (
     <div>
-      <h2>You searched for {UrlQuery.searchQuery}</h2>
+      <h2>You searched for {UrlQuery.term}</h2>
       <div>
         <section>
           <h3>Twitch results</h3>

--- a/test/queryHandling.test.ts
+++ b/test/queryHandling.test.ts
@@ -9,43 +9,41 @@ import {
 
 describe("Checking search query validity", () => {
   it("recognises empty search query as invalid", () => {
-    expect(isValidSearchQuery({ searchQuery: "" })).toBe(false);
+    expect(isValidSearchQuery({ term: "" })).toBe(false);
   });
 
   it("recognises whitespace search query as invalid", () => {
-    expect(isValidSearchQuery({ searchQuery: "   " })).toBe(false);
+    expect(isValidSearchQuery({ term: "   " })).toBe(false);
   });
 
-  it("recognises lack of searchQuery param as invalid", () => {
+  it("recognises lack of search term param as invalid", () => {
     expect(isValidSearchQuery({})).toBe(false);
   });
 
-  it("recognises array of searchQuery params as invalid", () => {
-    expect(isValidSearchQuery({ searchQuery: ["hello", "test"] })).toBe(false);
+  it("recognises array of search term params as invalid", () => {
+    expect(isValidSearchQuery({ term: ["hello", "test"] })).toBe(false);
   });
 
-  it("recognises multiple param query as invalid if searchQuery is not present", () => {
+  it("recognises multiple param query as invalid if search term is not present", () => {
     expect(isValidSearchQuery({ one: "hello", two: "true" })).toBe(false);
   });
 
-  it("recognises multiple param query as valid as long as searchQuery is included", () => {
-    expect(isValidSearchQuery({ searchQuery: "hello", term: "true" })).toBe(
-      true
-    );
+  it("recognises multiple param query as valid as long as search term is included", () => {
+    expect(isValidSearchQuery({ term: "hello", invalid: "true" })).toBe(true);
   });
 
   it("recognises valid search query", () => {
-    expect(isValidSearchQuery({ searchQuery: "hello" })).toBe(true);
+    expect(isValidSearchQuery({ term: "hello" })).toBe(true);
   });
 });
 
 describe("Performing search query sanitisation", () => {
   it("returns empty string for invalid search queries", () => {
-    expect(sanitiseSearchQuery({ term: "test" })).toBe("");
+    expect(sanitiseSearchQuery({ invalid: "test" })).toBe("");
   });
 
   it("returns the search query when it is valid", () => {
-    expect(sanitiseSearchQuery({ searchQuery: "test" })).toBe("test");
+    expect(sanitiseSearchQuery({ term: "test" })).toBe("test");
   });
 });
 
@@ -121,7 +119,7 @@ describe("Checking video ID query validity", () => {
 
 describe("Performing video ID query sanitisation", () => {
   it("returns empty string for invalid video IDs", () => {
-    expect(sanitiseVideoQuery({ term: "test" })).toBe("");
+    expect(sanitiseVideoQuery({ invalid: "test" })).toBe("");
   });
 
   it("returns the video ID when it is valid", () => {

--- a/utils/queryHandling.ts
+++ b/utils/queryHandling.ts
@@ -1,11 +1,11 @@
 import { ParsedUrlQuery } from "querystring";
 // These functions exist to help handle URL Query params relating to searching for channels/videos/etc.
 
-// Use this to ensure searchQueries provided via a URL are in the correct format for API calls
+// Use this to ensure search queries provided via a URL are in the correct format for API calls
 export const isValidSearchQuery = (query: ParsedUrlQuery) => {
-  if (typeof query.searchQuery === "string") {
-    // covers lack of searchQuery param
-    return query.searchQuery.trim() !== ""; // covers empty/whitespace strings
+  if (typeof query.term === "string") {
+    // covers lack of search query param
+    return query.term.trim() !== ""; // covers empty/whitespace strings
   }
   return false;
 };
@@ -14,7 +14,7 @@ export const isValidSearchQuery = (query: ParsedUrlQuery) => {
 export const sanitiseSearchQuery = (query: ParsedUrlQuery) => {
   if (isValidSearchQuery(query)) {
     // This is a safe type assertion as the valid query check has passed
-    return query.searchQuery as string;
+    return query.term as string;
   } else {
     return "";
   }


### PR DESCRIPTION
This PR converts the `searchQuery` query param into the simpler `term` query param to avoid camel case in the URL query. The `searchQuery` descriptor is still used within code however for variable naming to convey better meaning of what is happening.