### PR TITLE
Context adjustments

### DIFF
--- a/features/channels/components/youtube-channel/YouTubeChannel.tsx
+++ b/features/channels/components/youtube-channel/YouTubeChannel.tsx
@@ -1,0 +1,80 @@
+import { useGetYouTubeChannel } from "features/channels/hooks/useGetYouTubeChannel";
+import Image from "next/image";
+import { YouTubeChannelVideos } from "features/channels";
+
+interface YouTubeChannelProps {
+  channelId: string;
+}
+
+const YouTubeChannel = ({ channelId }: YouTubeChannelProps) => {
+  const { isLoading, isError, data } = useGetYouTubeChannel(channelId);
+
+  // TODO: a possible livestream solution
+  // useEffect(() => {
+  //   if (data && data.channelData) {
+  //     fetch(`https://cors-anywhere.herokuapp.com/https://www.youtube.com/channel/${data.channelData.id}`, {
+  //     })
+  //       .then((response) => response.text())
+  //       .then((data) => console.log(data))
+  //       .catch((err) => console.log(err))
+  //   }
+  // }, [data])
+
+  return (
+    <div>
+      {isLoading && <div>YouTube loading...</div>}
+
+      {isError && <div>An error has occurred</div>}
+
+      {data && (
+        <div>
+          {data.channelData ? (
+            <div>
+              <section>
+                <div>
+                  <h2>{data.channelData.snippet.title}</h2>
+                  <p>{data.channelData.snippet.description}</p>
+                  <Image
+                    src={data.channelData.snippet.thumbnails.medium.url}
+                    alt={`${data.channelData.snippet.title} channel thumbnail`}
+                    height={100}
+                    width={100}
+                  />
+                  {data.channelData.brandingSettings.image && (
+                    <Image
+                      src={
+                        data.channelData.brandingSettings.image
+                          .bannerExternalUrl
+                      }
+                      alt={`${data.channelData.snippet.title} channel banner`}
+                      height={100}
+                      width={100}
+                    />
+                  )}
+                </div>
+                <div>
+                  <p>
+                    {data.channelData.statistics.subscriberCount} subscribers
+                  </p>
+                  <p>{data.channelData.statistics.videoCount} videos</p>
+                </div>
+              </section>
+              <div>
+                {/*These will immediately be loaded, but will be obscured by an overlay within the component*/}
+                <YouTubeChannelVideos
+                  uploadsId={
+                    data.channelData.contentDetails.relatedPlaylists.uploads
+                  }
+                />
+              </div>
+            </div>
+          ) : (
+            <p>Channel not found</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default YouTubeChannel;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,20 +2,17 @@ import "styles/globals.css";
 import type { AppProps } from "next/app";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
-import { GapiContextProvider } from "providers/GapiContext";
 import { Layout } from "components/Layout";
 
 const queryClient = new QueryClient();
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <GapiContextProvider>
-      <QueryClientProvider client={queryClient}>
-        <Layout>
-          <Component {...pageProps} />
-        </Layout>
-        <ReactQueryDevtools initialIsOpen={false} />
-      </QueryClientProvider>
-    </GapiContextProvider>
+    <QueryClientProvider client={queryClient}>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
   );
 }

--- a/pages/youtube/channel/[channelId].tsx
+++ b/pages/youtube/channel/[channelId].tsx
@@ -1,11 +1,9 @@
-import { useGetYouTubeChannel } from "features/channels/hooks/useGetYouTubeChannel";
-import Image from "next/image";
-import { sanitiseChannelQuery } from "utils/queryHandling";
+import YouTubeChannel from "features/channels/components/youtube-channel/YouTubeChannel";
 import { GetServerSideProps } from "next";
-import { YouTubeChannelVideos } from "features/channels";
-import { useEffect } from "react";
+import { GapiContextProvider } from "providers/GapiContext";
+import { sanitiseChannelQuery } from "utils/queryHandling";
 
-interface YouTubeChannelProps {
+interface YouTubeChannelPageProps {
   channelId: string;
 }
 
@@ -18,75 +16,12 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   return { props: { channelId } };
 };
 
-const YouTubeChannel = ({ channelId }: YouTubeChannelProps) => {
-  const { isLoading, isError, data } = useGetYouTubeChannel(channelId);
-
-  // TODO: a possible livestream solution
-  // useEffect(() => {
-  //   if (data && data.channelData) {
-  //     fetch(`https://cors-anywhere.herokuapp.com/https://www.youtube.com/channel/${data.channelData.id}`, {
-  //     })
-  //       .then((response) => response.text())
-  //       .then((data) => console.log(data))
-  //       .catch((err) => console.log(err))
-  //   }
-  // }, [data])
-
+const Channel = ({ channelId }: YouTubeChannelPageProps) => {
   return (
-    <div>
-      {isLoading && <div>YouTube loading...</div>}
-
-      {isError && <div>An error has occurred</div>}
-
-      {data && (
-        <div>
-          {data.channelData ? (
-            <div>
-              <section>
-                <div>
-                  <h2>{data.channelData.snippet.title}</h2>
-                  <p>{data.channelData.snippet.description}</p>
-                  <Image
-                    src={data.channelData.snippet.thumbnails.medium.url}
-                    alt={`${data.channelData.snippet.title} channel thumbnail`}
-                    height={100}
-                    width={100}
-                  />
-                  {data.channelData.brandingSettings.image && (
-                    <Image
-                      src={
-                        data.channelData.brandingSettings.image
-                          .bannerExternalUrl
-                      }
-                      alt={`${data.channelData.snippet.title} channel banner`}
-                      height={100}
-                      width={100}
-                    />
-                  )}
-                </div>
-                <div>
-                  <p>
-                    {data.channelData.statistics.subscriberCount} subscribers
-                  </p>
-                  <p>{data.channelData.statistics.videoCount} videos</p>
-                </div>
-              </section>
-              <div>
-                {/*These will immediately be loaded, but will be obscured by an overlay within the component*/}
-                <YouTubeChannelVideos
-                  uploadsId={
-                    data.channelData.contentDetails.relatedPlaylists.uploads
-                  }
-                />
-              </div>
-            </div>
-          ) : (
-            <p>Channel not found</p>
-          )}
-        </div>
-      )}
-    </div>
+    <GapiContextProvider>
+      <YouTubeChannel channelId={channelId} />
+    </GapiContextProvider>
   );
 };
 
-export default YouTubeChannel;
+export default Channel;

--- a/pages/youtube/search.tsx
+++ b/pages/youtube/search.tsx
@@ -1,5 +1,6 @@
 import { YouTubeSearchTab } from "features/search";
 import { useRouter } from "next/router";
+import { GapiContextProvider } from "providers/GapiContext";
 import { isValidSearchQuery, sanitiseSearchQuery } from "utils/queryHandling";
 
 const Search = () => {
@@ -12,12 +13,14 @@ const Search = () => {
   }
 
   return (
-    <div>
-      <section>
-        <h3>YouTube results</h3>
-        <YouTubeSearchTab searchQuery={sanitiseSearchQuery(UrlQuery)} />
-      </section>
-    </div>
+    <GapiContextProvider>
+      <div>
+        <section>
+          <h3>YouTube results</h3>
+          <YouTubeSearchTab searchQuery={sanitiseSearchQuery(UrlQuery)} />
+        </section>
+      </div>
+    </GapiContextProvider>
   );
 };
 


### PR DESCRIPTION
This PR moves the `GapiContextProvider` into more selective component trees, i.e. only those YT components that require access to the API. This is an improvement on wrapping the entire application with the context when most of the app does not require it. Because so few components require it, we may move away from context if need be, in the future. 