### PR TITLE
Add all video settings

### DIFF
--- a/features/players/api/player.ts
+++ b/features/players/api/player.ts
@@ -23,6 +23,18 @@ export class Player implements PlayerClass {
     return this.playerWrapper.hasQualitySettings();
   }
 
+  getPlaybackSpeed() {
+    return this.playerWrapper.getPlaybackSpeed();
+  }
+
+  getAvailablePlaybackSpeeds() {
+    return this.playerWrapper.getAvailablePlaybackSpeeds();
+  }
+
+  setPlaybackSpeed(playbackSpeed: number) {
+    this.playerWrapper.setPlaybackSpeed(playbackSpeed);
+  }
+
   seek(timestamp: number, allowSeekAhead?: boolean) {
     if (allowSeekAhead) {
       this.playerWrapper.seek(timestamp, allowSeekAhead);

--- a/features/players/api/player.ts
+++ b/features/players/api/player.ts
@@ -20,7 +20,7 @@ export class Player implements PlayerClass {
   }
 
   hasPlaybackSpeedSettings() {
-    return this.playerWrapper.hasQualitySettings();
+    return this.playerWrapper.hasPlaybackSpeedSettings();
   }
 
   getPlaybackSpeed() {

--- a/features/players/api/player.ts
+++ b/features/players/api/player.ts
@@ -19,6 +19,14 @@ export class Player implements PlayerClass {
     return this.playerWrapper.hasQualitySettings();
   }
 
+  hasCaptionSettings() {
+    return this.playerWrapper.hasQualitySettings();
+  }
+
+  hasPlaybackSpeedSettings() {
+    return this.playerWrapper.hasQualitySettings();
+  }
+
   seek(timestamp: number, allowSeekAhead?: boolean) {
     if (allowSeekAhead) {
       this.playerWrapper.seek(timestamp, allowSeekAhead);

--- a/features/players/api/player.ts
+++ b/features/players/api/player.ts
@@ -19,10 +19,6 @@ export class Player implements PlayerClass {
     return this.playerWrapper.hasQualitySettings();
   }
 
-  hasCaptionSettings() {
-    return this.playerWrapper.hasQualitySettings();
-  }
-
   hasPlaybackSpeedSettings() {
     return this.playerWrapper.hasQualitySettings();
   }

--- a/features/players/api/twitchPlayerWrapper.ts
+++ b/features/players/api/twitchPlayerWrapper.ts
@@ -23,10 +23,6 @@ export class TwitchPlayerWrapper implements PlayerClass {
     return true;
   }
 
-  hasCaptionSettings() {
-    return true;
-  }
-
   hasPlaybackSpeedSettings() {
     return false;
   }

--- a/features/players/api/twitchPlayerWrapper.ts
+++ b/features/players/api/twitchPlayerWrapper.ts
@@ -27,6 +27,19 @@ export class TwitchPlayerWrapper implements PlayerClass {
     return false;
   }
 
+  // ! All playback speed functionality does not exist on Twitch Player API
+  getPlaybackSpeed() {
+    return 1;
+  }
+
+  getAvailablePlaybackSpeeds() {
+    return [1];
+  }
+
+  setPlaybackSpeed() {
+    return;
+  }
+
   seek(timestamp: number) {
     this.player.seek(timestamp);
   }

--- a/features/players/api/twitchPlayerWrapper.ts
+++ b/features/players/api/twitchPlayerWrapper.ts
@@ -23,6 +23,14 @@ export class TwitchPlayerWrapper implements PlayerClass {
     return true;
   }
 
+  hasCaptionSettings() {
+    return true;
+  }
+
+  hasPlaybackSpeedSettings() {
+    return false;
+  }
+
   seek(timestamp: number) {
     this.player.seek(timestamp);
   }

--- a/features/players/api/youtubePlayerWrapper.ts
+++ b/features/players/api/youtubePlayerWrapper.ts
@@ -27,6 +27,14 @@ export class YouTubePlayerWrapper implements PlayerClass {
     return false;
   }
 
+  hasCaptionSettings() {
+    return true;
+  }
+
+  hasPlaybackSpeedSettings() {
+    return true;
+  }
+
   // ! Deprecated functionality
   setQuality(quality: string) {
     this.player.setPlaybackQuality(quality);

--- a/features/players/api/youtubePlayerWrapper.ts
+++ b/features/players/api/youtubePlayerWrapper.ts
@@ -31,6 +31,18 @@ export class YouTubePlayerWrapper implements PlayerClass {
     return true;
   }
 
+  getPlaybackSpeed() {
+    return this.player.getPlaybackRate();
+  }
+
+  getAvailablePlaybackSpeeds() {
+    return this.player.getAvailablePlaybackRates();
+  }
+
+  setPlaybackSpeed(playbackSpeed: number) {
+    this.player.setPlaybackRate(playbackSpeed);
+  }
+
   // ! Deprecated functionality
   setQuality(quality: string) {
     this.player.setPlaybackQuality(quality);

--- a/features/players/api/youtubePlayerWrapper.ts
+++ b/features/players/api/youtubePlayerWrapper.ts
@@ -27,10 +27,6 @@ export class YouTubePlayerWrapper implements PlayerClass {
     return false;
   }
 
-  hasCaptionSettings() {
-    return true;
-  }
-
   hasPlaybackSpeedSettings() {
     return true;
   }

--- a/features/players/components/VideoControls.tsx
+++ b/features/players/components/VideoControls.tsx
@@ -190,7 +190,7 @@ export const VideoControls = ({
           <SettingsGearIcon className={styles.icons24} fill="#FFFFFF" />
         </button>
 
-        {player.hasQualitySettings() && showSettings && (
+        {showSettings && (
           <VideoSettings
             player={player}
             closeMenu={() => setShowSettings(false)}

--- a/features/players/components/VideoSettings.tsx
+++ b/features/players/components/VideoSettings.tsx
@@ -10,8 +10,8 @@ interface VideoSettingsProps {
 // Currently this menu only supports quality settings, but may be adapted later to include playback rate and caption settings
 export const VideoSettings = ({ closeMenu, player }: VideoSettingsProps) => {
   // Handles typical accessibility and UX concerns
-  useMenuCloseEvents("settingsMenu", closeMenu);
-  useKeyboardNavigation("settingsMenu");
+  // useMenuCloseEvents("settingsMenu", closeMenu);
+  // useKeyboardNavigation("settingsMenu");
 
   return (
     <ul
@@ -41,13 +41,26 @@ export const VideoSettings = ({ closeMenu, player }: VideoSettingsProps) => {
           </ul>
         </li>
       )}
-      <li>
-        <button role="menuitem">Subtitles</button>
-      </li>
-
-      <li>
-        <button role="menuitem">Playback Speed</button>
-      </li>
+      {player.hasPlaybackSpeedSettings() && (
+        <li>
+          <button role="menuitem">Playback Speed</button>
+          <ul>
+            {player.getAvailablePlaybackSpeeds().map((speed) => (
+              <li role="none" key={speed}>
+                <button
+                  role="menuitem"
+                  onClick={() => {
+                    player.setPlaybackSpeed(speed);
+                    closeMenu();
+                  }}
+                >
+                  {speed}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </li>
+      )}
     </ul>
   );
 };

--- a/features/players/components/VideoSettings.tsx
+++ b/features/players/components/VideoSettings.tsx
@@ -21,22 +21,33 @@ export const VideoSettings = ({ closeMenu, player }: VideoSettingsProps) => {
       aria-label="Video settings menu"
       data-testid="settingsMenu"
     >
-      {player.getQualities().map((quality) => (
-        <li role="none" key={quality.name}>
-          <button
-            role="menuitem"
-            onClick={() => {
-              player.setQuality(quality.level);
-              closeMenu();
-            }}
-          >
-            {/* Indicate the source quality option for the user*/}
-            {quality.level === "chunked"
-              ? `${quality.name} (Source)`
-              : `${quality.name}`}
-          </button>
+      {player.hasQualitySettings() && (
+        <li>
+          <button role="menuitem">Quality</button>
+          <ul>
+            {player.getQualities().map((quality) => (
+              <li role="none" key={quality.name}>
+                <button
+                  role="menuitem"
+                  onClick={() => {
+                    player.setQuality(quality.level);
+                    closeMenu();
+                  }}
+                >
+                  {quality.name}
+                </button>
+              </li>
+            ))}
+          </ul>
         </li>
-      ))}
+      )}
+      <li>
+        <button role="menuitem">Subtitles</button>
+      </li>
+
+      <li>
+        <button role="menuitem">Playback Speed</button>
+      </li>
     </ul>
   );
 };

--- a/features/players/components/VideoSettings.tsx
+++ b/features/players/components/VideoSettings.tsx
@@ -10,7 +10,7 @@ interface VideoSettingsProps {
 // Currently this menu only supports quality settings, but may be adapted later to include playback rate and caption settings
 export const VideoSettings = ({ closeMenu, player }: VideoSettingsProps) => {
   // Handles typical accessibility and UX concerns
-  // useMenuCloseEvents("settingsMenu", closeMenu);
+  useMenuCloseEvents("settingsMenu", closeMenu);
   // useKeyboardNavigation("settingsMenu");
 
   return (

--- a/features/players/components/__tests__/VideoControls.test.tsx
+++ b/features/players/components/__tests__/VideoControls.test.tsx
@@ -27,6 +27,9 @@ const playerMock = {
   hasQualitySettings: hasQualitySettingsMock,
   hasPlaybackSpeedSettings: () => true,
   hasCaptionSettings: () => true,
+  getPlaybackSpeed: () => 1,
+  getAvailablePlaybackSpeeds: () => [0.5, 1, 2],
+  setPlaybackSpeed: jest.fn,
 };
 
 let playerPausedMock = false;

--- a/features/players/components/__tests__/VideoControls.test.tsx
+++ b/features/players/components/__tests__/VideoControls.test.tsx
@@ -25,6 +25,8 @@ const playerMock = {
   ],
   setQuality: jest.fn,
   hasQualitySettings: hasQualitySettingsMock,
+  hasPlaybackSpeedSettings: () => true,
+  hasCaptionSettings: () => true,
 };
 
 let playerPausedMock = false;

--- a/features/players/components/__tests__/VideoPlayer.test.tsx
+++ b/features/players/components/__tests__/VideoPlayer.test.tsx
@@ -31,7 +31,6 @@ const playerWrapperPlaying: PlayerClass = {
     return [];
   },
   hasPlaybackSpeedSettings: () => true,
-  hasCaptionSettings: () => true,
 };
 
 const playerWrapperPaused: PlayerClass = {

--- a/features/players/components/__tests__/VideoPlayer.test.tsx
+++ b/features/players/components/__tests__/VideoPlayer.test.tsx
@@ -30,6 +30,8 @@ const playerWrapperPlaying: PlayerClass = {
   getQualities: () => {
     return [];
   },
+  hasPlaybackSpeedSettings: () => true,
+  hasCaptionSettings: () => true,
 };
 
 const playerWrapperPaused: PlayerClass = {

--- a/features/players/components/__tests__/VideoPlayer.test.tsx
+++ b/features/players/components/__tests__/VideoPlayer.test.tsx
@@ -31,6 +31,9 @@ const playerWrapperPlaying: PlayerClass = {
     return [];
   },
   hasPlaybackSpeedSettings: () => true,
+  getPlaybackSpeed: () => 1,
+  getAvailablePlaybackSpeeds: () => [1],
+  setPlaybackSpeed: jest.fn,
 };
 
 const playerWrapperPaused: PlayerClass = {

--- a/features/players/components/__tests__/VideoSettings.test.tsx
+++ b/features/players/components/__tests__/VideoSettings.test.tsx
@@ -21,7 +21,7 @@ const playerMock = {
   hasQualitySettings: () => true,
   hasPlaybackSpeedSettings: () => true,
   getPlaybackSpeed: () => 1,
-  getAvailablePlaybackSpeeds: () => [0.5, 1, 2],
+  getAvailablePlaybackSpeeds: () => [1, 2],
   setPlaybackSpeed: jest.fn,
 };
 
@@ -57,5 +57,25 @@ describe("Video settings menu", () => {
     });
     expect(qualitySettings).not.toBeInTheDocument();
     expect(speedSettings).toBeInTheDocument();
+  });
+
+  it("Shows all available qualities if that setting is present", () => {
+    playerMock.hasQualitySettings = () => true;
+    setup();
+    const auto = screen.getByText(/auto/i);
+    const hd720 = screen.getByText(/720p/i);
+    const hd1080 = screen.getByText(/1080p/i);
+    expect(auto).toBeInTheDocument();
+    expect(hd720).toBeInTheDocument();
+    expect(hd1080).toBeInTheDocument();
+  });
+
+  it("Shows all available playback speeds if that setting is present", () => {
+    playerMock.hasQualitySettings = () => false;
+    setup();
+    const one = screen.getByText(/1/i);
+    const two = screen.getByText(/2/i);
+    expect(one).toBeInTheDocument();
+    expect(two).toBeInTheDocument();
   });
 });

--- a/features/players/components/__tests__/VideoSettings.test.tsx
+++ b/features/players/components/__tests__/VideoSettings.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { VideoSettings } from "features/players";
+
+// Named mocks to test player functions being called
+const hasQualitySettingsMock = () => true;
+
+const playerMock = {
+  getCurrentTime: () => 1,
+  isMuted: () => false,
+  getVolume: jest.fn,
+  getQualities: () => [
+    {
+      name: "Auto",
+      level: "auto",
+    },
+    {
+      name: "1080p60",
+      level: "chunked",
+    },
+    {
+      name: "720p60",
+      level: "720p60",
+    },
+  ],
+  setQuality: jest.fn,
+  hasQualitySettings: hasQualitySettingsMock,
+};
+
+// The max test timeout should be increase to deal with waiting for timeout intervals in certain tests
+jest.setTimeout(10000);
+
+const setup = () => {
+  render(
+    <VideoSettings
+      // @ts-expect-error we don't require most player methods for testing, so a partial implementation is fine
+      player={playerMock}
+      closeMenu={jest.fn}
+    />
+  );
+};
+
+describe("Video settings menu", () => {
+  it("Shows all settings", () => {
+    setup();
+    expect(true).toBe(true);
+  });
+});

--- a/features/players/components/__tests__/VideoSettings.test.tsx
+++ b/features/players/components/__tests__/VideoSettings.test.tsx
@@ -20,6 +20,9 @@ const playerMock = {
   setQuality: jest.fn,
   hasQualitySettings: () => true,
   hasPlaybackSpeedSettings: () => true,
+  getPlaybackSpeed: () => 1,
+  getAvailablePlaybackSpeeds: () => [0.5, 1, 2],
+  setPlaybackSpeed: jest.fn,
 };
 
 const setup = () => {
@@ -39,11 +42,7 @@ describe("Video settings menu", () => {
     const speedSettings = screen.getByRole("menuitem", {
       name: /playback speed/i,
     });
-    const subtitleSettings = screen.getByRole("menuitem", {
-      name: /subtitles/i,
-    });
     expect(qualitySettings).toBeInTheDocument();
-    expect(subtitleSettings).toBeInTheDocument();
     expect(speedSettings).toBeInTheDocument();
   });
 
@@ -56,11 +55,7 @@ describe("Video settings menu", () => {
     const speedSettings = screen.getByRole("menuitem", {
       name: /playback speed/i,
     });
-    const subtitleSettings = screen.getByRole("menuitem", {
-      name: /subtitles/i,
-    });
     expect(qualitySettings).not.toBeInTheDocument();
-    expect(subtitleSettings).toBeInTheDocument();
     expect(speedSettings).toBeInTheDocument();
   });
 });

--- a/features/players/components/__tests__/VideoSettings.test.tsx
+++ b/features/players/components/__tests__/VideoSettings.test.tsx
@@ -41,8 +41,32 @@ const setup = () => {
 };
 
 describe("Video settings menu", () => {
-  it("Shows all settings", () => {
+  it("Shows all relevant settings where they are all available", () => {
     setup();
-    expect(true).toBe(true);
+    const qualitySettings = screen.getByRole("button", { name: /quality/ });
+    const speedSettings = screen.getByRole("button", {
+      name: /playback speed/,
+    });
+    const subtitleSettings = screen.getByRole("button", {
+      name: /playback speed/,
+    });
+    expect(qualitySettings).toBeInTheDocument();
+    expect(subtitleSettings).toBeInTheDocument();
+    expect(speedSettings).toBeInTheDocument();
+  });
+
+  it("Does not show settings that are not available for the video/platform", () => {
+    // TODO: Use different mock settings here for a YT replica
+    setup();
+    const qualitySettings = screen.queryByRole("button", { name: /quality/ });
+    const speedSettings = screen.getByRole("button", {
+      name: /playback speed/,
+    });
+    const subtitleSettings = screen.getByRole("button", {
+      name: /playback speed/,
+    });
+    expect(qualitySettings).not.toBeInTheDocument();
+    expect(subtitleSettings).toBeInTheDocument();
+    expect(speedSettings).toBeInTheDocument();
   });
 });

--- a/features/players/components/__tests__/VideoSettings.test.tsx
+++ b/features/players/components/__tests__/VideoSettings.test.tsx
@@ -19,6 +19,8 @@ const playerMock = {
   ],
   setQuality: jest.fn,
   hasQualitySettings: () => true,
+  hasPlaybackSpeedSettings: () => true,
+  hasCaptionSettings: () => true,
 };
 
 const setup = () => {

--- a/features/players/components/__tests__/VideoSettings.test.tsx
+++ b/features/players/components/__tests__/VideoSettings.test.tsx
@@ -2,13 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { VideoSettings } from "features/players";
 
-// Named mocks to test player functions being called
-const hasQualitySettingsMock = () => true;
-
 const playerMock = {
-  getCurrentTime: () => 1,
-  isMuted: () => false,
-  getVolume: jest.fn,
   getQualities: () => [
     {
       name: "Auto",
@@ -24,11 +18,8 @@ const playerMock = {
     },
   ],
   setQuality: jest.fn,
-  hasQualitySettings: hasQualitySettingsMock,
+  hasQualitySettings: () => true,
 };
-
-// The max test timeout should be increase to deal with waiting for timeout intervals in certain tests
-jest.setTimeout(10000);
 
 const setup = () => {
   render(
@@ -43,12 +34,12 @@ const setup = () => {
 describe("Video settings menu", () => {
   it("Shows all relevant settings where they are all available", () => {
     setup();
-    const qualitySettings = screen.getByRole("button", { name: /quality/ });
-    const speedSettings = screen.getByRole("button", {
-      name: /playback speed/,
+    const qualitySettings = screen.getByRole("menuitem", { name: /quality/i });
+    const speedSettings = screen.getByRole("menuitem", {
+      name: /playback speed/i,
     });
-    const subtitleSettings = screen.getByRole("button", {
-      name: /playback speed/,
+    const subtitleSettings = screen.getByRole("menuitem", {
+      name: /subtitles/i,
     });
     expect(qualitySettings).toBeInTheDocument();
     expect(subtitleSettings).toBeInTheDocument();
@@ -56,14 +47,16 @@ describe("Video settings menu", () => {
   });
 
   it("Does not show settings that are not available for the video/platform", () => {
-    // TODO: Use different mock settings here for a YT replica
+    playerMock.hasQualitySettings = () => false;
     setup();
-    const qualitySettings = screen.queryByRole("button", { name: /quality/ });
-    const speedSettings = screen.getByRole("button", {
-      name: /playback speed/,
+    const qualitySettings = screen.queryByRole("menuitem", {
+      name: /quality/i,
     });
-    const subtitleSettings = screen.getByRole("button", {
-      name: /playback speed/,
+    const speedSettings = screen.getByRole("menuitem", {
+      name: /playback speed/i,
+    });
+    const subtitleSettings = screen.getByRole("menuitem", {
+      name: /subtitles/i,
     });
     expect(qualitySettings).not.toBeInTheDocument();
     expect(subtitleSettings).toBeInTheDocument();

--- a/features/players/components/__tests__/VideoSettings.test.tsx
+++ b/features/players/components/__tests__/VideoSettings.test.tsx
@@ -20,7 +20,6 @@ const playerMock = {
   setQuality: jest.fn,
   hasQualitySettings: () => true,
   hasPlaybackSpeedSettings: () => true,
-  hasCaptionSettings: () => true,
 };
 
 const setup = () => {

--- a/features/players/types/playerTypes.ts
+++ b/features/players/types/playerTypes.ts
@@ -65,11 +65,6 @@ export interface PlayerClass {
   hasPlaybackSpeedSettings: () => boolean;
 
   /**
-   * Identifies whether the player allows manual adding/removing of closed captions
-   */
-  hasCaptionSettings: () => boolean;
-
-  /**
    * Sets the quality of the video.
    * @param quality   Video quality (string) from the available values
    */

--- a/features/players/types/playerTypes.ts
+++ b/features/players/types/playerTypes.ts
@@ -71,6 +71,22 @@ export interface PlayerClass {
   setQuality: (quality: string) => void;
 
   /**
+   * Sets the playback speed of the video.
+   * @param playbackSpeed   Playback speed of the video, may include values like 0.25, 0.5, 1, 1.5, and 2.
+   */
+  setPlaybackSpeed: (playbackSpeed: number) => void;
+
+  /**
+   * Retrieves the playback speed of the currently playing video.
+   */
+  getPlaybackSpeed: () => number;
+
+  /**
+   * Retrieves the set of playback speed available to the video.
+   */
+  getAvailablePlaybackSpeeds: () => number[];
+
+  /**
    * Sets the player volume.
    * @param volumeLevel   A number between 0 and 1.0.
    */

--- a/features/players/types/playerTypes.ts
+++ b/features/players/types/playerTypes.ts
@@ -60,6 +60,16 @@ export interface PlayerClass {
   hasQualitySettings: () => boolean;
 
   /**
+   * Identifies whether the player allows manual setting of playback speed
+   */
+  hasPlaybackSpeedSettings: () => boolean;
+
+  /**
+   * Identifies whether the player allows manual adding/removing of closed captions
+   */
+  hasCaptionSettings: () => boolean;
+
+  /**
    * Sets the quality of the video.
    * @param quality   Video quality (string) from the available values
    */

--- a/hooks/useKeyboardMenuNavigation.ts
+++ b/hooks/useKeyboardMenuNavigation.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 
 // Trap focus within a dropdown menu and handle arrow navigation (still allow user to tab out of menu)
-// ! The menu must have accessible menuitem roles, and be in hte form ul>li>button
+// ! The menu must have accessible menuitem roles, and be in the form ul>li>button
 export const useKeyboardNavigation = (elementId: string) => {
   useEffect(() => {
     const menu: HTMLUListElement | null = document.querySelector(


### PR DESCRIPTION
This PR adds all relevant video settings to the Video Player, with appropriate platform implementations where needed. It meets the following acceptance criteria:

- The video settings menu shows all possible video settings
- Each video setting can be selected and has the intended effect
- The video settings menu works for all platforms
- There is unit test coverage