### PR TITLE
Add key control indicators

### DIFF
--- a/features/players/components/VideoControlIndicator.tsx
+++ b/features/players/components/VideoControlIndicator.tsx
@@ -5,7 +5,7 @@ import PlayIcon from "icons/PlayIcon";
 import VolumeDownIcon from "icons/VolumeDownIcon";
 import VolumeIcon from "icons/VolumeIcon";
 import { ControlAction } from "./VideoPlayer";
-
+import * as React from "react";
 interface VideoControlIndicatorProps {
   ariaLabel: string;
   controlAction: ControlAction | null;
@@ -14,7 +14,6 @@ interface VideoControlIndicatorProps {
 
 const selectIcon = (action: ControlAction | null) => {
   let icon: JSX.Element | null = null;
-
   switch (action) {
     case "play":
       // Need at least one icon with an identifiable test icon for testing purposes
@@ -53,17 +52,34 @@ export const VideoControlIndicator = ({
   controlAction,
   triggerAnimation,
 }: VideoControlIndicatorProps) => {
+  const indicator = React.useRef<HTMLDivElement | null>(null);
+
+  React.useEffect(() => {
+    if (!indicator.current || !triggerAnimation) {
+      return;
+    }
+
+    indicator.current.classList.remove(styles.triggerAnimation);
+    // Triggers browser reflow, which is the only way to restart the CSS animation
+    void indicator.current.offsetWidth;
+    indicator.current.classList.add(styles.triggerAnimation);
+  }, [triggerAnimation]);
+
+  const handleAnimationEnd = () => {
+    if (!indicator.current) {
+      return;
+    }
+    indicator.current.classList.remove(styles.triggerAnimation);
+  };
   return (
     <div
-      className={`${styles.container} ${
-        triggerAnimation ? styles.triggerAnimation : styles.hide
-      }`}
+      className={`${styles.container}`}
       role="status"
       aria-label={ariaLabel}
+      ref={indicator}
+      onAnimationEnd={handleAnimationEnd}
     >
       <div className={styles.iconWrapper}>{selectIcon(controlAction)}</div>
     </div>
   );
 };
-
-// Animation 500 ms linear, scale + opacity

--- a/features/players/components/VideoControlIndicator.tsx
+++ b/features/players/components/VideoControlIndicator.tsx
@@ -11,7 +11,7 @@ export const VideoControlIndicator = ({
 }: VideoControlIndicatorProps) => {
   return (
     <div className={styles.container} role="status" aria-label={ariaLabel}>
-      {icon}
+      <div className={styles.iconWrapper}>{icon}</div>
     </div>
   );
 };

--- a/features/players/components/VideoControlIndicator.tsx
+++ b/features/players/components/VideoControlIndicator.tsx
@@ -54,23 +54,20 @@ export const VideoControlIndicator = ({
 }: VideoControlIndicatorProps) => {
   const indicator = React.useRef<HTMLDivElement | null>(null);
 
+  // Conceptually it makes sense to trigger the indicator animation with an effect.
   React.useEffect(() => {
-    if (!indicator.current || !triggerAnimation) {
-      return;
+    if (triggerAnimation && indicator.current !== null) {
+      indicator.current.classList.remove(styles.triggerAnimation);
+      // This triggers browser reflow, which is the only way to restart the CSS animation. It is a costly operation however, so keep this in mind if performance issues appear.
+      void indicator.current.offsetWidth;
+      indicator.current.classList.add(styles.triggerAnimation);
     }
-
-    indicator.current.classList.remove(styles.triggerAnimation);
-    // Triggers browser reflow, which is the only way to restart the CSS animation
-    void indicator.current.offsetWidth;
-    indicator.current.classList.add(styles.triggerAnimation);
   }, [triggerAnimation]);
 
-  const handleAnimationEnd = () => {
-    if (!indicator.current) {
-      return;
-    }
-    indicator.current.classList.remove(styles.triggerAnimation);
+  const handleAnimationEnd = (event: React.AnimationEvent<HTMLDivElement>) => {
+    event.currentTarget.classList.remove(styles.triggerAnimation);
   };
+
   return (
     <div
       className={`${styles.container}`}

--- a/features/players/components/VideoControlIndicator.tsx
+++ b/features/players/components/VideoControlIndicator.tsx
@@ -3,14 +3,22 @@ import styles from "features/players/components/styles/VideoControlIndicator.mod
 interface VideoControlIndicatorProps {
   ariaLabel: string;
   icon: React.ReactNode;
+  fadeOut: boolean;
 }
 
 export const VideoControlIndicator = ({
   ariaLabel,
   icon,
+  fadeOut,
 }: VideoControlIndicatorProps) => {
   return (
-    <div className={styles.container} role="status" aria-label={ariaLabel}>
+    <div
+      className={`${styles.container} ${
+        fadeOut ? styles.fadeOut : styles.hide
+      }`}
+      role="status"
+      aria-label={ariaLabel}
+    >
       <div className={styles.iconWrapper}>{icon}</div>
     </div>
   );

--- a/features/players/components/VideoControlIndicator.tsx
+++ b/features/players/components/VideoControlIndicator.tsx
@@ -3,18 +3,18 @@ import styles from "features/players/components/styles/VideoControlIndicator.mod
 interface VideoControlIndicatorProps {
   ariaLabel: string;
   icon: React.ReactNode;
-  fadeOut: boolean;
+  triggerAnimation: boolean;
 }
 
 export const VideoControlIndicator = ({
   ariaLabel,
   icon,
-  fadeOut,
+  triggerAnimation,
 }: VideoControlIndicatorProps) => {
   return (
     <div
       className={`${styles.container} ${
-        fadeOut ? styles.fadeOut : styles.hide
+        triggerAnimation ? styles.triggerAnimation : styles.hide
       }`}
       role="status"
       aria-label={ariaLabel}

--- a/features/players/components/VideoControlIndicator.tsx
+++ b/features/players/components/VideoControlIndicator.tsx
@@ -4,8 +4,9 @@ import PauseIcon from "icons/PauseIcon";
 import PlayIcon from "icons/PlayIcon";
 import VolumeDownIcon from "icons/VolumeDownIcon";
 import VolumeIcon from "icons/VolumeIcon";
-import { ControlAction } from "./VideoPlayer";
+import { ControlAction } from "../types/playerTypes";
 import * as React from "react";
+
 interface VideoControlIndicatorProps {
   ariaLabel: string;
   controlAction: ControlAction | null;

--- a/features/players/components/VideoControlIndicator.tsx
+++ b/features/players/components/VideoControlIndicator.tsx
@@ -56,7 +56,10 @@ export const VideoControlIndicator = ({
 
   // Conceptually it makes sense to trigger the indicator animation with an effect.
   React.useEffect(() => {
-    if (triggerAnimation && indicator.current !== null) {
+    if (indicator.current === null) {
+      return;
+    }
+    if (triggerAnimation) {
       indicator.current.classList.remove(styles.triggerAnimation);
       // This triggers browser reflow, which is the only way to restart the CSS animation. It is a costly operation however, so keep this in mind if performance issues appear.
       void indicator.current.offsetWidth;

--- a/features/players/components/VideoControlIndicator.tsx
+++ b/features/players/components/VideoControlIndicator.tsx
@@ -2,6 +2,7 @@ import styles from "features/players/components/styles/VideoControlIndicator.mod
 import MutedIcon from "icons/MutedIcon";
 import PauseIcon from "icons/PauseIcon";
 import PlayIcon from "icons/PlayIcon";
+import VolumeDownIcon from "icons/VolumeDownIcon";
 import VolumeIcon from "icons/VolumeIcon";
 import { ControlAction } from "./VideoPlayer";
 
@@ -29,6 +30,14 @@ const selectIcon = (action: ControlAction | null) => {
       break;
 
     case "unmute":
+      icon = <VolumeIcon fill="none" />;
+      break;
+
+    case "volumeDown":
+      icon = <VolumeDownIcon fill="#FFFFFF" />;
+      break;
+
+    case "volumeUp":
       icon = <VolumeIcon fill="none" />;
       break;
 

--- a/features/players/components/VideoControlIndicator.tsx
+++ b/features/players/components/VideoControlIndicator.tsx
@@ -18,7 +18,7 @@ const selectIcon = (action: ControlAction | null) => {
   switch (action) {
     case "play":
       // Need at least one icon with an identifiable test icon for testing purposes
-      icon = <PlayIcon testId="playIcon" fill="#FFFFFF" />;
+      icon = <PlayIcon testId="playIndicator" fill="#FFFFFF" />;
       break;
 
     case "pause":

--- a/features/players/components/VideoControlIndicator.tsx
+++ b/features/players/components/VideoControlIndicator.tsx
@@ -1,3 +1,5 @@
+import styles from "features/players/components/styles/VideoControlIndicator.module.css";
+
 interface VideoControlIndicatorProps {
   ariaLabel: string;
   icon: React.ReactNode;
@@ -8,7 +10,7 @@ export const VideoControlIndicator = ({
   icon,
 }: VideoControlIndicatorProps) => {
   return (
-    <div role="status" aria-label={ariaLabel}>
+    <div className={styles.container} role="status" aria-label={ariaLabel}>
       {icon}
     </div>
   );

--- a/features/players/components/VideoControlIndicator.tsx
+++ b/features/players/components/VideoControlIndicator.tsx
@@ -1,6 +1,8 @@
 import styles from "features/players/components/styles/VideoControlIndicator.module.css";
+import MutedIcon from "icons/MutedIcon";
 import PauseIcon from "icons/PauseIcon";
 import PlayIcon from "icons/PlayIcon";
+import VolumeIcon from "icons/VolumeIcon";
 import { ControlAction } from "./VideoPlayer";
 
 interface VideoControlIndicatorProps {
@@ -20,6 +22,14 @@ const selectIcon = (action: ControlAction | null) => {
 
     case "pause":
       icon = <PauseIcon fill="#FFFFFF" />;
+      break;
+
+    case "mute":
+      icon = <MutedIcon fill="#FFFFFF" />;
+      break;
+
+    case "unmute":
+      icon = <VolumeIcon fill="none" />;
       break;
 
     default:

--- a/features/players/components/VideoControlIndicator.tsx
+++ b/features/players/components/VideoControlIndicator.tsx
@@ -1,19 +1,25 @@
 import styles from "features/players/components/styles/VideoControlIndicator.module.css";
+import PauseIcon from "icons/PauseIcon";
 import PlayIcon from "icons/PlayIcon";
 import { ControlAction } from "./VideoPlayer";
 
 interface VideoControlIndicatorProps {
   ariaLabel: string;
-  controlAction: ControlAction;
+  controlAction: ControlAction | null;
   triggerAnimation: boolean;
 }
 
-const selectIcon = (action: ControlAction) => {
+const selectIcon = (action: ControlAction | null) => {
   let icon: JSX.Element | null = null;
 
   switch (action) {
     case "play":
-      icon = <PlayIcon testId="playIcon" />;
+      // Need at least one icon with an identifiable test icon for testing purposes
+      icon = <PlayIcon testId="playIcon" fill="#FFFFFF" />;
+      break;
+
+    case "pause":
+      icon = <PauseIcon fill="#FFFFFF" />;
       break;
 
     default:

--- a/features/players/components/VideoControlIndicator.tsx
+++ b/features/players/components/VideoControlIndicator.tsx
@@ -1,0 +1,17 @@
+interface VideoControlIndicatorProps {
+  ariaLabel: string;
+  icon: React.ReactNode;
+}
+
+export const VideoControlIndicator = ({
+  ariaLabel,
+  icon,
+}: VideoControlIndicatorProps) => {
+  return (
+    <div role="status" aria-label={ariaLabel}>
+      {icon}
+    </div>
+  );
+};
+
+// Animation 500 ms linear, scale + opacity

--- a/features/players/components/VideoControlIndicator.tsx
+++ b/features/players/components/VideoControlIndicator.tsx
@@ -1,14 +1,31 @@
 import styles from "features/players/components/styles/VideoControlIndicator.module.css";
+import PlayIcon from "icons/PlayIcon";
+import { ControlAction } from "./VideoPlayer";
 
 interface VideoControlIndicatorProps {
   ariaLabel: string;
-  icon: React.ReactNode;
+  controlAction: ControlAction;
   triggerAnimation: boolean;
 }
 
+const selectIcon = (action: ControlAction) => {
+  let icon: JSX.Element | null = null;
+
+  switch (action) {
+    case "play":
+      icon = <PlayIcon testId="playIcon" />;
+      break;
+
+    default:
+      break;
+  }
+
+  return icon;
+};
+
 export const VideoControlIndicator = ({
   ariaLabel,
-  icon,
+  controlAction,
   triggerAnimation,
 }: VideoControlIndicatorProps) => {
   return (
@@ -19,7 +36,7 @@ export const VideoControlIndicator = ({
       role="status"
       aria-label={ariaLabel}
     >
-      <div className={styles.iconWrapper}>{icon}</div>
+      <div className={styles.iconWrapper}>{selectIcon(controlAction)}</div>
     </div>
   );
 };

--- a/features/players/components/VideoControls.tsx
+++ b/features/players/components/VideoControls.tsx
@@ -69,7 +69,6 @@ export const VideoControls = ({
         <button
           className={styles.controlsBtn}
           onClick={togglePlay}
-          id="playBtn"
           aria-label={playerPaused ? "Play video" : "Pause video"}
         >
           {playerPaused ? (

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -8,7 +8,7 @@ import { VideoControls } from "features/players";
 import { Player } from "../api/player";
 import { useSeek } from "../hooks/useSeek";
 import { VideoControlIndicator } from "./VideoControlIndicator";
-import PauseIcon from "icons/PauseIcon";
+import { useControlIndicators } from "../hooks/useControlIndicators";
 
 export type ControlAction =
   | "play"
@@ -39,13 +39,14 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
     setLockUserActive,
   } = useUserActivity();
   const { scheduleSeek, projectedTime } = useSeek(player);
+  const { showControlIndicator, triggerControlIndication, controlAction } =
+    useControlIndicators();
   const wrapperRef = React.useRef<HTMLDivElement | null>(null);
 
   // Use local state to avoid the long delays of an API call to check muted state when toggling icons and UI
   const [playerMuted, setPlayerMuted] = React.useState(true);
   const [playerPaused, setPlayerPaused] = React.useState(false);
   const [theaterMode, setTheaterMode] = React.useState(false);
-  const [showControlIndicator, setShowControlIndicator] = React.useState(false);
 
   // Ensure the local playerState state is set on play/pause events. This ensures other elements modify with each of the changes as needed
   React.useEffect(() => {
@@ -92,7 +93,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
         triggerControlIndication("pause");
       }
     }
-  }, [player, signalUserInactivity]);
+  }, [player, signalUserInactivity, triggerControlIndication]);
 
   const toggleTheaterMode = () => {
     setTheaterMode((prevState) => !prevState);
@@ -100,15 +101,6 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
     if (wrapperRef.current) {
       wrapperRef.current.focus();
     }
-  };
-
-  const triggerControlIndication = (action: ControlAction) => {
-    setShowControlIndicator(true);
-    console.log(action);
-
-    setTimeout(() => {
-      setShowControlIndicator(false);
-    }, 450);
   };
 
   // A global keypress handler to allow the user to control the video regardless of where they are on the page.
@@ -195,7 +187,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
       <div className={styles.indicatorContainer}>
         <VideoControlIndicator
           ariaLabel="Play"
-          controlAction="play"
+          controlAction={controlAction}
           triggerAnimation={showControlIndicator}
         />
       </div>

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -177,7 +177,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
         <VideoControlIndicator
           ariaLabel="Pause"
           icon={<PauseIcon fill="#FFFFFF" />}
-          fadeOut={fadeControlIndicator}
+          triggerAnimation={fadeControlIndicator}
         />
       </div>
 

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -71,31 +71,28 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
     }
     if (player.getMuted()) {
       setPlayerMuted(false);
-      triggerControlIndication("unmute");
       player.setMuted(false);
     } else {
       setPlayerMuted(true);
-      triggerControlIndication("mute");
       player.setMuted(true);
     }
-  }, [player, signalUserActivity, triggerControlIndication]);
+  }, [player, signalUserActivity]);
 
   // Use this function to play a paused video, or pause a playing video. Intended to activate on clicking the video, or pressing spacebar
   const playOrPauseVideo = React.useCallback(() => {
     if (player) {
       if (player.isPaused()) {
         player.play();
-        triggerControlIndication("play");
+
         // A longer timeout is used here because it can be quite anti-user experience to have controls and cursor fade almost immediately after pressing play.
         setTimeout(() => {
           signalUserInactivity();
         }, 1000);
       } else {
         player.pause();
-        triggerControlIndication("pause");
       }
     }
-  }, [player, signalUserInactivity, triggerControlIndication]);
+  }, [player, signalUserInactivity]);
 
   const toggleTheaterMode = () => {
     setTheaterMode((prevState) => !prevState);
@@ -161,9 +158,19 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
         case "k":
         case " ":
           playOrPauseVideo();
+          if (playerPaused) {
+            triggerControlIndication("play");
+          } else {
+            triggerControlIndication("pause");
+          }
           break;
         case "m":
           toggleMute();
+          if (playerMuted) {
+            triggerControlIndication("mute");
+          } else {
+            triggerControlIndication("unmute");
+          }
           break;
         case "f":
           toggleFullscreen(wrapperRef.current);
@@ -180,7 +187,6 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
           } else {
             triggerControlIndication("volumeDown");
           }
-
           break;
         case "ArrowUp":
           player.setMuted(false);
@@ -210,6 +216,8 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
     signalUserActivity,
     scheduleSeek,
     triggerControlIndication,
+    playerMuted,
+    playerPaused,
   ]);
 
   return (
@@ -223,7 +231,14 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
         className={`${styles.overlay} ${
           userActive || playerPaused ? "" : styles.overlayInactive
         } ${disableControls ? styles.overlayDisabled : ""}`}
-        onClick={playOrPauseVideo}
+        onClick={() => {
+          playOrPauseVideo();
+          if (playerPaused) {
+            triggerControlIndication("play");
+          } else {
+            triggerControlIndication("pause");
+          }
+        }}
         onDoubleClick={() => toggleFullscreen(wrapperRef.current)}
         onMouseMove={throttleMousemove}
         data-testid="overlay"

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -10,6 +10,22 @@ import { useSeek } from "../hooks/useSeek";
 import { VideoControlIndicator } from "./VideoControlIndicator";
 import PauseIcon from "icons/PauseIcon";
 
+type Action =
+  | "play"
+  | "pause"
+  | "volumeUp"
+  | "volumeDown"
+  | "mute"
+  | "unmute"
+  | "forwardOneMins"
+  | "forwardFiveMins"
+  | "forwardTenMins"
+  | "forwardTenSecs"
+  | "backOneMins"
+  | "backFiveMins"
+  | "backTenMins"
+  | "backTenSecs";
+
 interface VideoPlayerProps {
   player: Player | null;
   disableControls?: boolean;
@@ -29,7 +45,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
   const [playerMuted, setPlayerMuted] = React.useState(true);
   const [playerPaused, setPlayerPaused] = React.useState(false);
   const [theaterMode, setTheaterMode] = React.useState(false);
-  const [fadeControlIndicator, setFadeControlIndicator] = React.useState(false);
+  const [showControlIndicator, setShowControlIndicator] = React.useState(false);
 
   // Ensure the local playerState state is set on play/pause events. This ensures other elements modify with each of the changes as needed
   React.useEffect(() => {
@@ -66,12 +82,14 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
     if (player) {
       if (player.isPaused()) {
         player.play();
+        triggerControlIndication("play");
         // A longer timeout is used here because it can be quite anti-user experience to have controls and cursor fade almost immediately after pressing play.
         setTimeout(() => {
           signalUserInactivity();
         }, 1000);
       } else {
         player.pause();
+        triggerControlIndication("pause");
       }
     }
   }, [player, signalUserInactivity]);
@@ -84,10 +102,12 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
     }
   };
 
-  const triggerControlIndication = () => {
-    setFadeControlIndicator(true);
+  const triggerControlIndication = (action: Action) => {
+    setShowControlIndicator(true);
+    console.log(action);
+
     setTimeout(() => {
-      setFadeControlIndicator(false);
+      setShowControlIndicator(false);
     }, 450);
   };
 
@@ -123,7 +143,6 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
         case "k":
         case " ":
           playOrPauseVideo();
-          triggerControlIndication();
           break;
         case "m":
           toggleMute();
@@ -177,7 +196,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
         <VideoControlIndicator
           ariaLabel="Pause"
           icon={<PauseIcon fill="#FFFFFF" />}
-          triggerAnimation={fadeControlIndicator}
+          triggerAnimation={showControlIndicator}
         />
       </div>
 

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -29,6 +29,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
   const [playerMuted, setPlayerMuted] = React.useState(true);
   const [playerPaused, setPlayerPaused] = React.useState(false);
   const [theaterMode, setTheaterMode] = React.useState(false);
+  const [fadeControlIndicator, setFadeControlIndicator] = React.useState(false);
 
   // Ensure the local playerState state is set on play/pause events. This ensures other elements modify with each of the changes as needed
   React.useEffect(() => {
@@ -83,6 +84,13 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
     }
   };
 
+  const triggerControlIndication = () => {
+    setFadeControlIndicator(true);
+    setTimeout(() => {
+      setFadeControlIndicator(false);
+    }, 450);
+  };
+
   // A global keypress handler to allow the user to control the video regardless of where they are on the page.
   React.useEffect(() => {
     const activeUserKeys = [
@@ -115,6 +123,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
         case "k":
         case " ":
           playOrPauseVideo();
+          triggerControlIndication();
           break;
         case "m":
           toggleMute();
@@ -168,6 +177,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
         <VideoControlIndicator
           ariaLabel="Pause"
           icon={<PauseIcon fill="#FFFFFF" />}
+          fadeOut={fadeControlIndicator}
         />
       </div>
 

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -149,9 +149,11 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
           break;
         case "ArrowDown":
           player.setVolume(player.getVolume() - 0.05);
+          triggerControlIndication("volumeDown");
           break;
         case "ArrowUp":
           player.setVolume(player.getVolume() + 0.05);
+          triggerControlIndication("volumeUp");
           break;
         case "ArrowLeft":
           scheduleSeek(-10);
@@ -168,7 +170,14 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
     return () => {
       window.removeEventListener("keydown", handleKeyPress);
     };
-  }, [playOrPauseVideo, player, toggleMute, signalUserActivity, scheduleSeek]);
+  }, [
+    playOrPauseVideo,
+    player,
+    toggleMute,
+    signalUserActivity,
+    scheduleSeek,
+    triggerControlIndication,
+  ]);
 
   return (
     <VideoContainer

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -7,6 +7,8 @@ import VideoContainer from "./VideoContainer";
 import { VideoControls } from "features/players";
 import { Player } from "../api/player";
 import { useSeek } from "../hooks/useSeek";
+import { VideoControlIndicator } from "./VideoControlIndicator";
+import PauseIcon from "icons/PauseIcon";
 
 interface VideoPlayerProps {
   player: Player | null;
@@ -162,6 +164,12 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
         onMouseMove={throttleMousemove}
         data-testid="overlay"
       ></div>
+      <div className={styles.indicatorContainer}>
+        <VideoControlIndicator
+          ariaLabel="Pause"
+          icon={<PauseIcon fill="#FFFFFF" />}
+        />
+      </div>
 
       {player && (
         <div

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -10,22 +10,6 @@ import { useSeek } from "../hooks/useSeek";
 import { VideoControlIndicator } from "./VideoControlIndicator";
 import { useControlIndicators } from "../hooks/useControlIndicators";
 
-export type ControlAction =
-  | "play"
-  | "pause"
-  | "volumeUp"
-  | "volumeDown"
-  | "mute"
-  | "unmute"
-  | "forwardOneMins"
-  | "forwardFiveMins"
-  | "forwardTenMins"
-  | "forwardTenSecs"
-  | "backOneMins"
-  | "backFiveMins"
-  | "backTenMins"
-  | "backTenSecs";
-
 interface VideoPlayerProps {
   player: Player | null;
   disableControls?: boolean;

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -173,9 +173,18 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
           break;
         case "ArrowDown":
           player.setVolume(player.getVolume() - 0.05);
-          triggerControlIndication("volumeDown");
+          if (player.getVolume() === 0) {
+            setPlayerMuted(true);
+            player.setMuted(true);
+            triggerControlIndication("mute");
+          } else {
+            triggerControlIndication("volumeDown");
+          }
+
           break;
         case "ArrowUp":
+          player.setMuted(false);
+          setPlayerMuted(false);
           player.setVolume(player.getVolume() + 0.05);
           triggerControlIndication("volumeUp");
           break;

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -167,9 +167,9 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
         case "m":
           toggleMute();
           if (playerMuted) {
-            triggerControlIndication("mute");
-          } else {
             triggerControlIndication("unmute");
+          } else {
+            triggerControlIndication("mute");
           }
           break;
         case "f":

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -10,7 +10,7 @@ import { useSeek } from "../hooks/useSeek";
 import { VideoControlIndicator } from "./VideoControlIndicator";
 import PauseIcon from "icons/PauseIcon";
 
-type Action =
+export type ControlAction =
   | "play"
   | "pause"
   | "volumeUp"
@@ -102,7 +102,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
     }
   };
 
-  const triggerControlIndication = (action: Action) => {
+  const triggerControlIndication = (action: ControlAction) => {
     setShowControlIndicator(true);
     console.log(action);
 
@@ -194,8 +194,8 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
       ></div>
       <div className={styles.indicatorContainer}>
         <VideoControlIndicator
-          ariaLabel="Pause"
-          icon={<PauseIcon fill="#FFFFFF" />}
+          ariaLabel="Play"
+          controlAction="play"
           triggerAnimation={showControlIndicator}
         />
       </div>

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -71,12 +71,14 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
     }
     if (player.getMuted()) {
       setPlayerMuted(false);
+      triggerControlIndication("unmute");
       player.setMuted(false);
     } else {
       setPlayerMuted(true);
+      triggerControlIndication("mute");
       player.setMuted(true);
     }
-  }, [player, signalUserActivity]);
+  }, [player, signalUserActivity, triggerControlIndication]);
 
   // Use this function to play a paused video, or pause a playing video. Intended to activate on clicking the video, or pressing spacebar
   const playOrPauseVideo = React.useCallback(() => {

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -109,23 +109,47 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
   React.useEffect(() => {
     const activeUserKeys = [
       "m",
+      "k",
+      "f",
+      "t",
       "ArrowDown",
       "ArrowUp",
       "ArrowLeft",
       "ArrowRight",
     ];
 
+    const activeDOMKeys = ["ArrowDown", "ArrowUp", "ArrowLeft", "ArrowRight"];
+
     const handleKeyPress = (event: KeyboardEvent) => {
-      const { nodeName, className } = event.target as HTMLElement;
+      if (!(event.target instanceof Element)) {
+        return;
+      }
+
+      const { nodeName, className } = event.target;
+      const withinPlayer = event.target.closest("#wrapper");
 
       // Ensure these key actions do not mess with normal button expectations and functionality
       if (nodeName === "BUTTON" || nodeName === "INPUT") {
         if (className.includes("controlsBtn")) {
           signalUserActivity();
-        } else return;
+        }
+        return;
       }
 
-      if (activeUserKeys.includes(event.key)) {
+      // Avoid scrolling the page. Always prioritise play/pause functionality.
+      if (event.key === " ") {
+        event.preventDefault();
+      }
+
+      if (activeDOMKeys.includes(event.key) && !withinPlayer) {
+        return;
+      }
+
+      if (
+        activeUserKeys.includes(event.key) &&
+        wrapperRef.current === document.activeElement
+      ) {
+        event.preventDefault();
         signalUserActivity();
       }
 

--- a/features/players/components/__tests__/VideoControlIndicator.test.tsx
+++ b/features/players/components/__tests__/VideoControlIndicator.test.tsx
@@ -8,11 +8,11 @@ describe("Control indicator rendering and prop handling", () => {
     render(
       <VideoControlIndicator
         triggerAnimation={false}
-        ariaLabel="Pause"
-        icon={<PauseIcon testId="pauseIndicator" />}
+        ariaLabel="Play"
+        controlAction="play"
       />
     );
-    const icon = screen.getByTestId(/pauseIndicator/i);
+    const icon = screen.getByTestId(/playIcon/i);
     expect(icon).toBeInTheDocument();
   });
 
@@ -20,11 +20,11 @@ describe("Control indicator rendering and prop handling", () => {
     render(
       <VideoControlIndicator
         triggerAnimation={false}
-        ariaLabel="Pause"
-        icon={<PauseIcon />}
+        ariaLabel="Play"
+        controlAction="play"
       />
     );
-    const accessibleElement = screen.getByLabelText("Pause");
+    const accessibleElement = screen.getByLabelText("Play");
     expect(accessibleElement).toBeInTheDocument();
   });
 
@@ -32,8 +32,8 @@ describe("Control indicator rendering and prop handling", () => {
     render(
       <VideoControlIndicator
         triggerAnimation={false}
-        ariaLabel="Pause"
-        icon={<PauseIcon />}
+        ariaLabel="Play"
+        controlAction="play"
       />
     );
     const indicator = screen.getByRole("status");
@@ -44,8 +44,8 @@ describe("Control indicator rendering and prop handling", () => {
     render(
       <VideoControlIndicator
         triggerAnimation={true}
-        ariaLabel="Pause"
-        icon={<PauseIcon />}
+        ariaLabel="Play"
+        controlAction="play"
       />
     );
     const indicator = screen.getByRole("status");

--- a/features/players/components/__tests__/VideoControlIndicator.test.tsx
+++ b/features/players/components/__tests__/VideoControlIndicator.test.tsx
@@ -7,6 +7,7 @@ describe("Control indicator rendering and prop handling", () => {
   it("Shows correct icon passed in via props", () => {
     render(
       <VideoControlIndicator
+        fadeOut={false}
         ariaLabel="Pause"
         icon={<PauseIcon testId="pauseIndicator" />}
       />
@@ -16,7 +17,13 @@ describe("Control indicator rendering and prop handling", () => {
   });
 
   it("Has correct accessible name and role", () => {
-    render(<VideoControlIndicator ariaLabel="Pause" icon={<PauseIcon />} />);
+    render(
+      <VideoControlIndicator
+        fadeOut={false}
+        ariaLabel="Pause"
+        icon={<PauseIcon />}
+      />
+    );
     const accessibleElement = screen.getByLabelText("Pause");
     expect(accessibleElement).toBeInTheDocument();
   });

--- a/features/players/components/__tests__/VideoControlIndicator.test.tsx
+++ b/features/players/components/__tests__/VideoControlIndicator.test.tsx
@@ -11,7 +11,7 @@ describe("Control indicator rendering and prop handling", () => {
         controlAction="play"
       />
     );
-    const icon = screen.getByTestId(/playIcon/i);
+    const icon = screen.getByTestId(/playIndicator/i);
     expect(icon).toBeInTheDocument();
   });
 

--- a/features/players/components/__tests__/VideoControlIndicator.test.tsx
+++ b/features/players/components/__tests__/VideoControlIndicator.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import PauseIcon from "icons/PauseIcon";
 import { VideoControlIndicator } from "../VideoControlIndicator";
 
 describe("Control indicator rendering and prop handling", () => {

--- a/features/players/components/__tests__/VideoControlIndicator.test.tsx
+++ b/features/players/components/__tests__/VideoControlIndicator.test.tsx
@@ -5,9 +5,14 @@ import { VideoControlIndicator } from "../VideoControlIndicator";
 
 describe("Control indicator rendering and prop handling", () => {
   it("Shows correct icon passed in via props", () => {
-    render(<VideoControlIndicator ariaLabel="Pause" icon={<PauseIcon />} />);
-    const currentSpeed = screen.getByText(/Normal/i);
-    expect(currentSpeed).toBeInTheDocument();
+    render(
+      <VideoControlIndicator
+        ariaLabel="Pause"
+        icon={<PauseIcon testId="pauseIndicator" />}
+      />
+    );
+    const icon = screen.getByTestId(/pauseIndicator/i);
+    expect(icon).toBeInTheDocument();
   });
 
   it("Has correct accessible name and role", () => {

--- a/features/players/components/__tests__/VideoControlIndicator.test.tsx
+++ b/features/players/components/__tests__/VideoControlIndicator.test.tsx
@@ -27,7 +27,7 @@ describe("Control indicator rendering and prop handling", () => {
     expect(accessibleElement).toBeInTheDocument();
   });
 
-  it("Hides indicator by default", () => {
+  it("Hides indicator when trigger animation is not required", () => {
     render(
       <VideoControlIndicator
         triggerAnimation={false}
@@ -36,10 +36,10 @@ describe("Control indicator rendering and prop handling", () => {
       />
     );
     const indicator = screen.getByRole("status");
-    expect(indicator).toHaveClass("hide");
+    expect(indicator).not.toHaveClass("triggerAnimation");
   });
 
-  it("Shows indicator when trigger animation is active", () => {
+  it("Shows indicator when trigger animation is required", () => {
     render(
       <VideoControlIndicator
         triggerAnimation={true}

--- a/features/players/components/__tests__/VideoControlIndicator.test.tsx
+++ b/features/players/components/__tests__/VideoControlIndicator.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { VideoControlIndicator } from "../VideoControlIndicator";
 
 describe("Control indicator rendering and prop handling", () => {

--- a/features/players/components/__tests__/VideoControlIndicator.test.tsx
+++ b/features/players/components/__tests__/VideoControlIndicator.test.tsx
@@ -4,10 +4,10 @@ import PauseIcon from "icons/PauseIcon";
 import { VideoControlIndicator } from "../VideoControlIndicator";
 
 describe("Control indicator rendering and prop handling", () => {
-  it("Shows correct icon passed in via props", () => {
+  it("Render correct icon passed in via props", () => {
     render(
       <VideoControlIndicator
-        fadeOut={false}
+        triggerAnimation={false}
         ariaLabel="Pause"
         icon={<PauseIcon testId="pauseIndicator" />}
       />
@@ -19,12 +19,36 @@ describe("Control indicator rendering and prop handling", () => {
   it("Has correct accessible name and role", () => {
     render(
       <VideoControlIndicator
-        fadeOut={false}
+        triggerAnimation={false}
         ariaLabel="Pause"
         icon={<PauseIcon />}
       />
     );
     const accessibleElement = screen.getByLabelText("Pause");
     expect(accessibleElement).toBeInTheDocument();
+  });
+
+  it("Hides indicator by default", () => {
+    render(
+      <VideoControlIndicator
+        triggerAnimation={false}
+        ariaLabel="Pause"
+        icon={<PauseIcon />}
+      />
+    );
+    const indicator = screen.getByRole("status");
+    expect(indicator).toHaveClass("hide");
+  });
+
+  it("Shows indicator when trigger animation is active", () => {
+    render(
+      <VideoControlIndicator
+        triggerAnimation={true}
+        ariaLabel="Pause"
+        icon={<PauseIcon />}
+      />
+    );
+    const indicator = screen.getByRole("status");
+    expect(indicator).toHaveClass("triggerAnimation");
   });
 });

--- a/features/players/components/__tests__/VideoControlIndicator.test.tsx
+++ b/features/players/components/__tests__/VideoControlIndicator.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import PauseIcon from "icons/PauseIcon";
+import { VideoControlIndicator } from "../VideoControlIndicator";
+
+describe("Control indicator rendering and prop handling", () => {
+  it("Shows correct icon passed in via props", () => {
+    render(<VideoControlIndicator ariaLabel="Pause" icon={<PauseIcon />} />);
+    const currentSpeed = screen.getByText(/Normal/i);
+    expect(currentSpeed).toBeInTheDocument();
+  });
+
+  it("Has correct accessible name and role", () => {
+    render(<VideoControlIndicator ariaLabel="Pause" icon={<PauseIcon />} />);
+    const accessibleElement = screen.getByLabelText("Pause");
+    expect(accessibleElement).toBeInTheDocument();
+  });
+});

--- a/features/players/components/__tests__/VideoPlayer.test.tsx
+++ b/features/players/components/__tests__/VideoPlayer.test.tsx
@@ -307,3 +307,40 @@ describe("Video player controls/user activity timers", () => {
     expect(customControls).toHaveClass("controlsHide");
   });
 });
+
+describe("Video player control indicators", () => {
+  it("Shows then fades control indicator when pausing/playing video with keyboard", async () => {
+    render(<VideoPlayer player={player} />);
+    const wrapper = screen.getByTestId("wrapper");
+
+    // First focus the wrapper to ensure the keypress is captured correctly
+    wrapper.focus();
+    await userEvent.keyboard("k");
+
+    const playIndicator = screen.getByRole("status");
+
+    expect(playIndicator).toBeInTheDocument();
+    expect(playIndicator).toHaveClass("triggerAnimation");
+
+    // Allow time for the indicator to fade
+    await act(async () => {
+      await new Promise((res) => setTimeout(res, 600));
+    });
+
+    expect(playIndicator).toHaveClass("hide");
+  });
+
+  it("Does not show control indicator when playing/pausing video with control", async () => {
+    render(<VideoPlayer player={player} />);
+
+    // First hover the relevant div to trigger user activity/controls to show
+    const overlay = screen.getByTestId("overlay");
+    await userEvent.hover(overlay);
+
+    const playBtn = screen.getByLabelText(/pause video/i);
+    await userEvent.click(playBtn);
+
+    const playIndicator = screen.getByRole("status");
+    expect(playIndicator).toHaveClass("hide");
+  });
+});

--- a/features/players/components/__tests__/VideoPlayer.test.tsx
+++ b/features/players/components/__tests__/VideoPlayer.test.tsx
@@ -309,7 +309,7 @@ describe("Video player controls/user activity timers", () => {
 });
 
 describe("Video player control indicators", () => {
-  it("Shows then fades control indicator when pausing/playing video with keyboard", async () => {
+  it("Shows control indicator when pausing/playing video with keyboard", async () => {
     render(<VideoPlayer player={player} />);
     const wrapper = screen.getByTestId("wrapper");
 
@@ -321,13 +321,6 @@ describe("Video player control indicators", () => {
 
     expect(indicator).toBeInTheDocument();
     expect(indicator).toHaveClass("triggerAnimation");
-
-    // Allow time for the indicator to fade
-    await act(async () => {
-      await new Promise((res) => setTimeout(res, 600));
-    });
-
-    expect(indicator).toHaveClass("hide");
   });
 
   it("Does not show control indicator when playing/pausing video with control", async () => {
@@ -341,7 +334,7 @@ describe("Video player control indicators", () => {
     await userEvent.click(playBtn);
 
     const indicator = screen.getByRole("status");
-    expect(indicator).toHaveClass("hide");
+    expect(indicator).not.toHaveClass("triggerAnimation");
   });
 
   it("Shows control indicator when pausing/playing video by clicking on video overlay", async () => {
@@ -355,12 +348,5 @@ describe("Video player control indicators", () => {
 
     expect(indicator).toBeInTheDocument();
     expect(indicator).toHaveClass("triggerAnimation");
-
-    // Allow time for the indicator to fade
-    await act(async () => {
-      await new Promise((res) => setTimeout(res, 600));
-    });
-
-    expect(indicator).toHaveClass("hide");
   });
 });

--- a/features/players/components/__tests__/VideoPlayer.test.tsx
+++ b/features/players/components/__tests__/VideoPlayer.test.tsx
@@ -317,17 +317,17 @@ describe("Video player control indicators", () => {
     wrapper.focus();
     await userEvent.keyboard("k");
 
-    const playIndicator = screen.getByRole("status");
+    const indicator = screen.getByRole("status");
 
-    expect(playIndicator).toBeInTheDocument();
-    expect(playIndicator).toHaveClass("triggerAnimation");
+    expect(indicator).toBeInTheDocument();
+    expect(indicator).toHaveClass("triggerAnimation");
 
     // Allow time for the indicator to fade
     await act(async () => {
       await new Promise((res) => setTimeout(res, 600));
     });
 
-    expect(playIndicator).toHaveClass("hide");
+    expect(indicator).toHaveClass("hide");
   });
 
   it("Does not show control indicator when playing/pausing video with control", async () => {
@@ -340,7 +340,27 @@ describe("Video player control indicators", () => {
     const playBtn = screen.getByLabelText(/pause video/i);
     await userEvent.click(playBtn);
 
-    const playIndicator = screen.getByRole("status");
-    expect(playIndicator).toHaveClass("hide");
+    const indicator = screen.getByRole("status");
+    expect(indicator).toHaveClass("hide");
+  });
+
+  it("Shows control indicator when pausing/playing video by clicking on video overlay", async () => {
+    render(<VideoPlayer player={player} />);
+
+    // First hover the relevant div to trigger user activity/controls to show
+    const overlay = screen.getByTestId("overlay");
+    await userEvent.click(overlay);
+
+    const indicator = screen.getByRole("status");
+
+    expect(indicator).toBeInTheDocument();
+    expect(indicator).toHaveClass("triggerAnimation");
+
+    // Allow time for the indicator to fade
+    await act(async () => {
+      await new Promise((res) => setTimeout(res, 600));
+    });
+
+    expect(indicator).toHaveClass("hide");
   });
 });

--- a/features/players/components/styles/TwitchPlayer.module.css
+++ b/features/players/components/styles/TwitchPlayer.module.css
@@ -98,3 +98,15 @@
   opacity: 0;
   transition: opacity 1s;
 }
+
+.indicatorContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}

--- a/features/players/components/styles/TwitchPlayer.module.css
+++ b/features/players/components/styles/TwitchPlayer.module.css
@@ -110,7 +110,3 @@
   height: 100%;
   pointer-events: none;
 }
-
-.hide {
-  display: none;
-}

--- a/features/players/components/styles/TwitchPlayer.module.css
+++ b/features/players/components/styles/TwitchPlayer.module.css
@@ -110,3 +110,7 @@
   height: 100%;
   pointer-events: none;
 }
+
+.hide {
+  display: none;
+}

--- a/features/players/components/styles/VideoControlIndicator.module.css
+++ b/features/players/components/styles/VideoControlIndicator.module.css
@@ -1,0 +1,3 @@
+.container {
+  pointer-events: none;
+}

--- a/features/players/components/styles/VideoControlIndicator.module.css
+++ b/features/players/components/styles/VideoControlIndicator.module.css
@@ -8,9 +8,29 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  opacity: 1;
 }
 
 .iconWrapper {
   width: 2.5rem;
   height: 2.5rem;
+}
+
+.fadeOut {
+  animation: fade-out 500ms linear;
+}
+
+@keyframes fade-out {
+  0% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+    transform: scale(2);
+  }
+}
+
+.hide {
+  display: none;
 }

--- a/features/players/components/styles/VideoControlIndicator.module.css
+++ b/features/players/components/styles/VideoControlIndicator.module.css
@@ -9,6 +9,7 @@
   align-items: center;
   justify-content: center;
   opacity: 1;
+  display: none;
 }
 
 .iconWrapper {
@@ -17,6 +18,7 @@
 }
 
 .triggerAnimation {
+  display: flex;
   animation: fade-out 500ms linear;
 }
 
@@ -29,8 +31,4 @@
     opacity: 0;
     transform: scale(2);
   }
-}
-
-.hide {
-  display: none;
 }

--- a/features/players/components/styles/VideoControlIndicator.module.css
+++ b/features/players/components/styles/VideoControlIndicator.module.css
@@ -12,8 +12,8 @@
 }
 
 .iconWrapper {
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 2rem;
+  height: 2rem;
 }
 
 .triggerAnimation {

--- a/features/players/components/styles/VideoControlIndicator.module.css
+++ b/features/players/components/styles/VideoControlIndicator.module.css
@@ -16,7 +16,7 @@
   height: 2.5rem;
 }
 
-.fadeOut {
+.triggerAnimation {
   animation: fade-out 500ms linear;
 }
 

--- a/features/players/components/styles/VideoControlIndicator.module.css
+++ b/features/players/components/styles/VideoControlIndicator.module.css
@@ -1,14 +1,12 @@
 .container {
   pointer-events: none;
   background-color: rgba(0, 0, 0, 0.5);
-  color: rgb(238, 238, 238);
   height: 3.25rem;
   width: 3.25rem;
   border-radius: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
-  opacity: 1;
   display: none;
 }
 

--- a/features/players/components/styles/VideoControlIndicator.module.css
+++ b/features/players/components/styles/VideoControlIndicator.module.css
@@ -1,3 +1,16 @@
 .container {
   pointer-events: none;
+  background-color: rgba(0, 0, 0, 0.5);
+  color: rgb(238, 238, 238);
+  height: 3.25rem;
+  width: 3.25rem;
+  border-radius: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.iconWrapper {
+  width: 2.5rem;
+  height: 2.5rem;
 }

--- a/features/players/hooks/useControlIndicators.tsx
+++ b/features/players/hooks/useControlIndicators.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { ControlAction } from "../components/VideoPlayer";
+
+// Use this hook to trigger control indicators whent he user activates certain player controls
+export const useControlIndicators = () => {
+  const [controlAction, setControlAction] =
+    React.useState<ControlAction | null>(null);
+  const [showControlIndicator, setShowControlIndicator] = React.useState(false);
+
+  const triggerControlIndication = React.useCallback(
+    (action: ControlAction) => {
+      setShowControlIndicator(true);
+      setControlAction(action);
+
+      // The delay here must be LOWER than the CSS animation associated, otherwise there is a flash of the control icon after the animation completes
+      setTimeout(() => {
+        setShowControlIndicator(false);
+      }, 450);
+    },
+    []
+  );
+
+  return {
+    controlAction,
+    showControlIndicator,
+    triggerControlIndication,
+  };
+};

--- a/features/players/hooks/useControlIndicators.tsx
+++ b/features/players/hooks/useControlIndicators.tsx
@@ -12,10 +12,10 @@ export const useControlIndicators = () => {
       setShowControlIndicator(true);
       setControlAction(action);
 
-      // The delay here must be LOWER than the CSS animation associated, otherwise there is a flash of the control icon after the animation completes
-      setTimeout(() => {
+      // This gives us the quickest and most conceptually correct cancellation of triggering the indicator animation (as opposed to a setTimeout), and allows the animation to be restarted up to 60 times/second.
+      window.requestAnimationFrame(() => {
         setShowControlIndicator(false);
-      }, 450);
+      });
     },
     []
   );

--- a/features/players/hooks/useControlIndicators.tsx
+++ b/features/players/hooks/useControlIndicators.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ControlAction } from "../components/VideoPlayer";
+import { ControlAction } from "../types/playerTypes";
 
 // Use this hook to trigger control indicators whent he user activates certain player controls
 export const useControlIndicators = () => {

--- a/features/players/types/playerTypes.ts
+++ b/features/players/types/playerTypes.ts
@@ -1,3 +1,19 @@
+export type ControlAction =
+  | "play"
+  | "pause"
+  | "volumeUp"
+  | "volumeDown"
+  | "mute"
+  | "unmute"
+  | "forwardOneMins"
+  | "forwardFiveMins"
+  | "forwardTenMins"
+  | "forwardTenSecs"
+  | "backOneMins"
+  | "backFiveMins"
+  | "backTenMins"
+  | "backTenSecs";
+
 export interface VideoQualityObject {
   name: string;
   level: string;

--- a/icons/VolumeDownIcon.tsx
+++ b/icons/VolumeDownIcon.tsx
@@ -1,0 +1,21 @@
+interface VolumeDownIconProps {
+  className?: string;
+  fill?: string;
+  testId?: string;
+}
+
+const VolumeDownIcon = ({ className, fill, testId }: VolumeDownIconProps) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill={fill}
+      className={className ? className : undefined}
+      data-testid={testId ? testId : undefined}
+    >
+      <path d="M10 30V18h8L28 8v32L18 30Zm21 2.4V15.55q2.7.85 4.35 3.2Q37 21.1 37 24q0 2.95-1.65 5.25T31 32.4Zm-6-16.8L19.35 21H13v6h6.35L25 32.45ZM18.9 24Z" />
+    </svg>
+  );
+};
+
+export default VolumeDownIcon;

--- a/icons/VolumeDownIcon.tsx
+++ b/icons/VolumeDownIcon.tsx
@@ -13,7 +13,8 @@ const VolumeDownIcon = ({ className, fill, testId }: VolumeDownIconProps) => {
       className={className ? className : undefined}
       data-testid={testId ? testId : undefined}
     >
-      <path d="M10 30V18h8L28 8v32L18 30Zm21 2.4V15.55q2.7.85 4.35 3.2Q37 21.1 37 24q0 2.95-1.65 5.25T31 32.4Zm-6-16.8L19.35 21H13v6h6.35L25 32.45ZM18.9 24Z" />
+      <path d="M0 0h24v24H0z" fill="none" />
+      <path d="M18.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM5 9v6h4l5 5V4L9 9H5z" />
     </svg>
   );
 };


### PR DESCRIPTION
This PR adds the major player feature of visible (and accessible) indicators when the user uses a control via keyboard. Only the basic indicators are included, more specialised indicators are handled in their own issues. The following acceptance criteria are met:

- Every keyboard accessible video control shows a visual indication that it has been used
- Styling is consistent for all controls, but with unique icons (see YT design). 
- Accessibility (announcing that the control has been used?) has been considered
- There is unit test coverage