### PR TITLE
Volume level indicator

### DIFF
--- a/features/players/api/twitchPlayerWrapper.ts
+++ b/features/players/api/twitchPlayerWrapper.ts
@@ -49,11 +49,11 @@ export class TwitchPlayerWrapper implements PlayerClass {
   }
 
   setVolume(volumeLevel: number) {
-    this.player.setVolume(volumeLevel);
+    this.player.setVolume(volumeLevel / 100);
   }
 
   getVolume() {
-    return this.player.getVolume();
+    return this.player.getVolume() * 100;
   }
 
   setMuted(muted: boolean) {

--- a/features/players/api/twitchPlayerWrapper.ts
+++ b/features/players/api/twitchPlayerWrapper.ts
@@ -49,6 +49,11 @@ export class TwitchPlayerWrapper implements PlayerClass {
   }
 
   setVolume(volumeLevel: number) {
+    // The Twitch API has an unusual bug that lets you exceed 100% volume when switching on and off mute. Limit this behaviour here.
+    if (volumeLevel > 100) {
+      return;
+    }
+
     this.player.setVolume(volumeLevel / 100);
   }
 

--- a/features/players/api/youtubePlayerWrapper.ts
+++ b/features/players/api/youtubePlayerWrapper.ts
@@ -49,11 +49,11 @@ export class YouTubePlayerWrapper implements PlayerClass {
   }
 
   setVolume(volumeLevel: number) {
-    this.player.setVolume(volumeLevel * 100);
+    this.player.setVolume(volumeLevel);
   }
 
   getVolume() {
-    return this.player.getVolume() / 100;
+    return this.player.getVolume();
   }
 
   setMuted(muted: boolean) {

--- a/features/players/components/VideoControlIndicator.tsx
+++ b/features/players/components/VideoControlIndicator.tsx
@@ -8,7 +8,7 @@ import { ControlAction } from "../types/playerTypes";
 import * as React from "react";
 
 interface VideoControlIndicatorProps {
-  ariaLabel: string;
+  ariaLabel: string | null;
   controlAction: ControlAction | null;
   triggerAnimation: boolean;
 }
@@ -33,7 +33,6 @@ const selectIcon = (action: ControlAction | null) => {
       icon = <VolumeIcon fill="none" />;
       break;
 
-    // TODO: Remove aria labels for volume up/down an instead have this on the volume level indicator
     case "volumeDown":
       icon = <VolumeDownIcon fill="#FFFFFF" />;
       break;
@@ -56,6 +55,11 @@ export const VideoControlIndicator = ({
 }: VideoControlIndicatorProps) => {
   const indicator = React.useRef<HTMLDivElement | null>(null);
 
+  // For volume adjustments, the aria label will be on a separate volume indicator and shouldn't be duplicated elsewhere
+  const ariaLabelRequired = () => {
+    return !(controlAction == "volumeDown" || controlAction === "volumeUp");
+  };
+
   // Conceptually it makes sense to trigger the indicator animation with an effect.
   React.useEffect(() => {
     if (indicator.current === null) {
@@ -77,7 +81,9 @@ export const VideoControlIndicator = ({
     <div
       className={`${styles.container}`}
       role="status"
-      aria-label={ariaLabel}
+      aria-label={
+        ariaLabelRequired() && ariaLabel !== null ? ariaLabel : undefined
+      }
       ref={indicator}
       onAnimationEnd={handleAnimationEnd}
     >

--- a/features/players/components/VideoControlIndicator.tsx
+++ b/features/players/components/VideoControlIndicator.tsx
@@ -33,6 +33,7 @@ const selectIcon = (action: ControlAction | null) => {
       icon = <VolumeIcon fill="none" />;
       break;
 
+    // TODO: Remove aria labels for volume up/down an instead have this on the volume level indicator
     case "volumeDown":
       icon = <VolumeDownIcon fill="#FFFFFF" />;
       break;

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -169,7 +169,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
           toggleTheaterMode();
           break;
         case "ArrowDown":
-          player.setVolume(player.getVolume() - 0.05);
+          player.setVolume(player.getVolume() - 5);
           if (player.getVolume() === 0) {
             setPlayerMuted(true);
             player.setMuted(true);
@@ -182,7 +182,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
         case "ArrowUp":
           player.setMuted(false);
           setPlayerMuted(false);
-          player.setVolume(player.getVolume() + 0.05);
+          player.setVolume(player.getVolume() + 5);
           triggerControlIndication("volumeUp");
           triggerVolumeLevelIndication();
           break;
@@ -237,10 +237,9 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
         data-testid="overlay"
       ></div>
       <div className={styles.indicatorContainer}>
-        {/* {showVolumeLevelIndicator && player && (
+        {showVolumeLevelIndicator && player && (
           <VolumeLevelIndicator currentVolume={player.getVolume()} />
-        )} */}
-        {player && <VolumeLevelIndicator currentVolume={player.getVolume()} />}
+        )}
         <VideoControlIndicator
           ariaLabel="Play"
           controlAction={controlAction}

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -9,6 +9,7 @@ import { Player } from "../api/player";
 import { useSeek } from "../hooks/useSeek";
 import { VideoControlIndicator } from "./VideoControlIndicator";
 import { useControlIndicators } from "../hooks/useControlIndicators";
+import { VolumeLevelIndicator } from "./VolumeLevelIndicator";
 
 interface VideoPlayerProps {
   player: Player | null;
@@ -23,8 +24,13 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
     setLockUserActive,
   } = useUserActivity();
   const { scheduleSeek, projectedTime } = useSeek(player);
-  const { showControlIndicator, triggerControlIndication, controlAction } =
-    useControlIndicators();
+  const {
+    showControlIndicator,
+    triggerControlIndication,
+    controlAction,
+    triggerVolumeLevelIndication,
+    showVolumeLevelIndicator,
+  } = useControlIndicators();
   const wrapperRef = React.useRef<HTMLDivElement | null>(null);
 
   // Use local state to avoid the long delays of an API call to check muted state when toggling icons and UI
@@ -171,12 +177,14 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
           } else {
             triggerControlIndication("volumeDown");
           }
+          triggerVolumeLevelIndication();
           break;
         case "ArrowUp":
           player.setMuted(false);
           setPlayerMuted(false);
           player.setVolume(player.getVolume() + 0.05);
           triggerControlIndication("volumeUp");
+          triggerVolumeLevelIndication();
           break;
         case "ArrowLeft":
           scheduleSeek(-10);
@@ -202,6 +210,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
     triggerControlIndication,
     playerMuted,
     playerPaused,
+    triggerVolumeLevelIndication,
   ]);
 
   return (
@@ -228,6 +237,9 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
         data-testid="overlay"
       ></div>
       <div className={styles.indicatorContainer}>
+        {showVolumeLevelIndicator && player && (
+          <VolumeLevelIndicator currentVolume={player.getVolume()} />
+        )}
         <VideoControlIndicator
           ariaLabel="Play"
           controlAction={controlAction}

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -241,7 +241,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
           <VolumeLevelIndicator currentVolume={player.getVolume()} />
         )}
         <VideoControlIndicator
-          ariaLabel="Play"
+          ariaLabel={controlAction}
           controlAction={controlAction}
           triggerAnimation={showControlIndicator}
         />

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -237,9 +237,10 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
         data-testid="overlay"
       ></div>
       <div className={styles.indicatorContainer}>
-        {showVolumeLevelIndicator && player && (
+        {/* {showVolumeLevelIndicator && player && (
           <VolumeLevelIndicator currentVolume={player.getVolume()} />
-        )}
+        )} */}
+        {player && <VolumeLevelIndicator currentVolume={player.getVolume()} />}
         <VideoControlIndicator
           ariaLabel="Play"
           controlAction={controlAction}

--- a/features/players/components/VolumeLevelIndicator.tsx
+++ b/features/players/components/VolumeLevelIndicator.tsx
@@ -7,7 +7,7 @@ interface VolumeLevelIndicatorProps {
 export const VolumeLevelIndicator = ({
   currentVolume,
 }: VolumeLevelIndicatorProps) => {
-  const volumeAsPercentage = `${(currentVolume * 100).toFixed(0)}%`;
+  const volumeAsPercentage = `${currentVolume.toFixed(0)}%`;
 
   return (
     <div

--- a/features/players/components/VolumeLevelIndicator.tsx
+++ b/features/players/components/VolumeLevelIndicator.tsx
@@ -5,5 +5,11 @@ interface VolumeLevelIndicatorProps {
 export const VolumeLevelIndicator = ({
   currentVolume,
 }: VolumeLevelIndicatorProps) => {
-  return <div>{currentVolume}</div>;
+  const volumeAsPercentage = `${currentVolume * 100}%`;
+
+  return (
+    <div aria-label={`Volume level ${volumeAsPercentage}`}>
+      {volumeAsPercentage}
+    </div>
+  );
 };

--- a/features/players/components/VolumeLevelIndicator.tsx
+++ b/features/players/components/VolumeLevelIndicator.tsx
@@ -7,7 +7,7 @@ interface VolumeLevelIndicatorProps {
 export const VolumeLevelIndicator = ({
   currentVolume,
 }: VolumeLevelIndicatorProps) => {
-  const volumeAsPercentage = `${currentVolume * 100}%`;
+  const volumeAsPercentage = `${(currentVolume * 100).toFixed(0)}%`;
 
   return (
     <div

--- a/features/players/components/VolumeLevelIndicator.tsx
+++ b/features/players/components/VolumeLevelIndicator.tsx
@@ -1,3 +1,5 @@
+import styles from "features/players/components/styles/VolumeLevelIndicator.module.css";
+
 interface VolumeLevelIndicatorProps {
   currentVolume: number;
 }
@@ -8,7 +10,10 @@ export const VolumeLevelIndicator = ({
   const volumeAsPercentage = `${currentVolume * 100}%`;
 
   return (
-    <div aria-label={`Volume level ${volumeAsPercentage}`}>
+    <div
+      className={styles.container}
+      aria-label={`Volume level ${volumeAsPercentage}`}
+    >
       {volumeAsPercentage}
     </div>
   );

--- a/features/players/components/VolumeLevelIndicator.tsx
+++ b/features/players/components/VolumeLevelIndicator.tsx
@@ -1,0 +1,9 @@
+interface VolumeLevelIndicatorProps {
+  currentVolume: number;
+}
+
+export const VolumeLevelIndicator = ({
+  currentVolume,
+}: VolumeLevelIndicatorProps) => {
+  return <div>{currentVolume}</div>;
+};

--- a/features/players/components/__tests__/VideoControlIndicator.test.tsx
+++ b/features/players/components/__tests__/VideoControlIndicator.test.tsx
@@ -6,7 +6,7 @@ describe("Control indicator rendering and prop handling", () => {
     render(
       <VideoControlIndicator
         triggerAnimation={false}
-        ariaLabel="Play"
+        ariaLabel="play"
         controlAction="play"
       />
     );
@@ -18,11 +18,11 @@ describe("Control indicator rendering and prop handling", () => {
     render(
       <VideoControlIndicator
         triggerAnimation={false}
-        ariaLabel="Play"
+        ariaLabel="play"
         controlAction="play"
       />
     );
-    const accessibleElement = screen.getByLabelText("Play");
+    const accessibleElement = screen.getByLabelText("play");
     expect(accessibleElement).toBeInTheDocument();
   });
 
@@ -30,7 +30,7 @@ describe("Control indicator rendering and prop handling", () => {
     render(
       <VideoControlIndicator
         triggerAnimation={false}
-        ariaLabel="Play"
+        ariaLabel="play"
         controlAction="play"
       />
     );
@@ -42,11 +42,23 @@ describe("Control indicator rendering and prop handling", () => {
     render(
       <VideoControlIndicator
         triggerAnimation={true}
-        ariaLabel="Play"
+        ariaLabel="play"
         controlAction="play"
       />
     );
     const indicator = screen.getByRole("status");
     expect(indicator).toHaveClass("triggerAnimation");
+  });
+
+  it("Avoid aria label for volume adjustments", () => {
+    render(
+      <VideoControlIndicator
+        triggerAnimation={true}
+        ariaLabel="volumeUp"
+        controlAction="volumeUp"
+      />
+    );
+    const indicator = screen.queryByLabelText("volumeUp");
+    expect(indicator).not.toBeInTheDocument();
   });
 });

--- a/features/players/components/__tests__/VideoPlayer.test.tsx
+++ b/features/players/components/__tests__/VideoPlayer.test.tsx
@@ -362,4 +362,22 @@ describe("Video player control indicators", () => {
 
     expect(indicator).toBeInTheDocument();
   });
+
+  it("Volume indicator disappears after certain time", async () => {
+    render(<VideoPlayer player={player} />);
+    const wrapper = screen.getByTestId("wrapper");
+
+    // First focus the wrapper to ensure the keypress is captured correctly
+    wrapper.focus();
+    await userEvent.keyboard("[ArrowUp]");
+
+    const indicator = screen.queryByText("50%");
+    expect(indicator).toBeInTheDocument();
+
+    await act(async () => {
+      await new Promise((res) => setTimeout(res, 600));
+    });
+
+    expect(indicator).not.toBeInTheDocument();
+  });
 });

--- a/features/players/components/__tests__/VideoPlayer.test.tsx
+++ b/features/players/components/__tests__/VideoPlayer.test.tsx
@@ -20,7 +20,7 @@ const playerWrapperPlaying: PlayerClass = {
   seek: seekMock,
   setVolume: setVolumeMock,
   getVolume: () => {
-    return 0.5;
+    return 50;
   },
   addEventListener: jest.fn,
   hasQualitySettings: () => {

--- a/features/players/components/__tests__/VideoPlayer.test.tsx
+++ b/features/players/components/__tests__/VideoPlayer.test.tsx
@@ -20,7 +20,7 @@ const playerWrapperPlaying: PlayerClass = {
   seek: seekMock,
   setVolume: setVolumeMock,
   getVolume: () => {
-    return 0;
+    return 0.5;
   },
   addEventListener: jest.fn,
   hasQualitySettings: () => {
@@ -348,5 +348,18 @@ describe("Video player control indicators", () => {
 
     expect(indicator).toBeInTheDocument();
     expect(indicator).toHaveClass("triggerAnimation");
+  });
+
+  it("Shows volume indicator when adjusting volume via keyboard (ArrowUp)", async () => {
+    render(<VideoPlayer player={player} />);
+    const wrapper = screen.getByTestId("wrapper");
+
+    // First focus the wrapper to ensure the keypress is captured correctly
+    wrapper.focus();
+    await userEvent.keyboard("[ArrowUp]");
+
+    const indicator = screen.getByText("50%");
+
+    expect(indicator).toBeInTheDocument();
   });
 });

--- a/features/players/components/__tests__/VolumeLevelIndicator.test.tsx
+++ b/features/players/components/__tests__/VolumeLevelIndicator.test.tsx
@@ -3,13 +3,13 @@ import { render, screen } from "@testing-library/react";
 
 describe("Volume level indicator UI", () => {
   it("Shows correct volume percentage", () => {
-    render(<VolumeLevelIndicator currentVolume={0.5} />);
+    render(<VolumeLevelIndicator currentVolume={50} />);
     const volumeLevel = screen.getByText("50%");
     expect(volumeLevel).toBeInTheDocument();
   });
 
   it("Has correct accessible description", () => {
-    render(<VolumeLevelIndicator currentVolume={0.5} />);
+    render(<VolumeLevelIndicator currentVolume={50} />);
     const volumeLabel = screen.getByLabelText("Volume level 50%");
     expect(volumeLabel).toBeInTheDocument();
   });

--- a/features/players/components/__tests__/VolumeLevelIndicator.test.tsx
+++ b/features/players/components/__tests__/VolumeLevelIndicator.test.tsx
@@ -10,7 +10,7 @@ describe("Volume level indicator UI", () => {
 
   it("Has correct accessible description", () => {
     render(<VolumeLevelIndicator currentVolume={0.5} />);
-    const volumeLabel = screen.getByLabelText("Volume level is 50%");
+    const volumeLabel = screen.getByLabelText("Volume level 50%");
     expect(volumeLabel).toBeInTheDocument();
   });
 });

--- a/features/players/components/__tests__/VolumeLevelIndicator.test.tsx
+++ b/features/players/components/__tests__/VolumeLevelIndicator.test.tsx
@@ -1,0 +1,16 @@
+import { VolumeLevelIndicator } from "../VolumeLevelIndicator";
+import { render, screen } from "@testing-library/react";
+
+describe("Volume level indicator UI", () => {
+  it("Shows correct volume percentage", () => {
+    render(<VolumeLevelIndicator currentVolume={0.5} />);
+    const volumeLevel = screen.getByText("50%");
+    expect(volumeLevel).toBeInTheDocument();
+  });
+
+  it("Has correct accessible description", () => {
+    render(<VolumeLevelIndicator currentVolume={0.5} />);
+    const volumeLabel = screen.getByLabelText("Volume level is 50%");
+    expect(volumeLabel).toBeInTheDocument();
+  });
+});

--- a/features/players/components/styles/TwitchPlayer.module.css
+++ b/features/players/components/styles/TwitchPlayer.module.css
@@ -101,6 +101,7 @@
 
 .indicatorContainer {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   position: absolute;

--- a/features/players/components/styles/TwitchPlayer.module.css
+++ b/features/players/components/styles/TwitchPlayer.module.css
@@ -100,14 +100,12 @@
 }
 
 .indicatorContainer {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
   pointer-events: none;
+  display: flex;
+  align-items: center;
 }

--- a/features/players/components/styles/VideoControlIndicator.module.css
+++ b/features/players/components/styles/VideoControlIndicator.module.css
@@ -7,7 +7,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  display: none;
+  /* display: none; */
 }
 
 .iconWrapper {

--- a/features/players/components/styles/VideoControlIndicator.module.css
+++ b/features/players/components/styles/VideoControlIndicator.module.css
@@ -7,7 +7,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  /* display: none; */
+  display: none;
+  position: absolute;
+  top: calc(50% - 1.625rem);
+  left: calc(50% - 1.625rem);
 }
 
 .iconWrapper {

--- a/features/players/components/styles/VolumeLevelIndicator.module.css
+++ b/features/players/components/styles/VolumeLevelIndicator.module.css
@@ -1,8 +1,12 @@
 .container {
   pointer-events: none;
   background-color: rgba(0, 0, 0, 0.5);
-  height: 4rem;
-  width: 4rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 3rem;
+  width: 5rem;
   color: white;
-  font-size: 1.5rem;
+  font-size: 1.25rem;
+  border-radius: 5px;
 }

--- a/features/players/components/styles/VolumeLevelIndicator.module.css
+++ b/features/players/components/styles/VolumeLevelIndicator.module.css
@@ -1,0 +1,8 @@
+.container {
+  pointer-events: none;
+  background-color: rgba(0, 0, 0, 0.5);
+  height: 4rem;
+  width: 4rem;
+  color: white;
+  font-size: 1.5rem;
+}

--- a/features/players/components/styles/VolumeLevelIndicator.module.css
+++ b/features/players/components/styles/VolumeLevelIndicator.module.css
@@ -9,4 +9,7 @@
   color: white;
   font-size: 1.25rem;
   border-radius: 5px;
+  position: absolute;
+  top: calc(12.5%);
+  left: calc(50% - 2.5rem);
 }

--- a/features/players/hooks/useControlIndicators.tsx
+++ b/features/players/hooks/useControlIndicators.tsx
@@ -6,6 +6,10 @@ export const useControlIndicators = () => {
   const [controlAction, setControlAction] =
     React.useState<ControlAction | null>(null);
   const [showControlIndicator, setShowControlIndicator] = React.useState(false);
+  const [showVolumeLevelIndicator, setShowVolumeLevelIndicator] =
+    React.useState(false);
+
+  const timer = React.useRef<NodeJS.Timeout | null>(null);
 
   const triggerControlIndication = React.useCallback(
     (action: ControlAction) => {
@@ -20,9 +24,20 @@ export const useControlIndicators = () => {
     []
   );
 
+  const triggerVolumeLevelIndication = React.useCallback(() => {
+    setShowVolumeLevelIndicator(true);
+    clearTimeout(timer.current as NodeJS.Timeout);
+
+    timer.current = setTimeout(() => {
+      setShowVolumeLevelIndicator(false);
+    }, 500);
+  }, []);
+
   return {
     controlAction,
     showControlIndicator,
     triggerControlIndication,
+    triggerVolumeLevelIndication,
+    showVolumeLevelIndicator,
   };
 };

--- a/features/players/types/playerTypes.ts
+++ b/features/players/types/playerTypes.ts
@@ -104,12 +104,12 @@ export interface PlayerClass {
 
   /**
    * Sets the player volume.
-   * @param volumeLevel   A number between 0 and 1.0.
+   * @param volumeLevel   A number between 0 and 100.
    */
   setVolume: (volumeLevel: number) => void;
 
   /**
-   * @returns Volume level, a number between 0 and 1.0.
+   * @returns Volume level, a number between 0 and 100.
    */
   getVolume: () => number;
 


### PR DESCRIPTION
This PR adds a visible volume level indicator whenever the user adjusts volume with the keyboard. It meets the following acceptance criteria:

- Volume level is shown (as a percentage) as a separate indicator when adjusting volume with keyboard.
- It should replicate the YT design (i.e., no scale/fade-out animation), and sit at the top of the player
- The accessibility should be dynamic in terms of announcing volume amount.
- There is unit test coverage