### PR TITLE
Seek indicator

### DIFF
--- a/features/players/components/SeekIndicator.tsx
+++ b/features/players/components/SeekIndicator.tsx
@@ -1,6 +1,5 @@
 import styles from "features/players/components/styles/SeekIndicator.module.css";
 import PlayIcon from "icons/PlayIcon";
-import { useEffect, useRef } from "react";
 import { convertSecondsToHumanReadable } from "utils/videoDurationConversion";
 
 interface SeekIndicatorProps {
@@ -37,6 +36,7 @@ export const SeekIndicator = ({
             className={`${styles.icon} ${styles.iconStart} ${
               projectedSeekInSeconds < 0 ? styles.iconBackward : ""
             }`}
+            testId="playIcon"
           />
           <PlayIcon
             fill="#ebebeb"

--- a/features/players/components/SeekIndicator.tsx
+++ b/features/players/components/SeekIndicator.tsx
@@ -31,25 +31,16 @@ export const SeekIndicator = ({
             projectedSeekInSeconds < 0 ? styles.iconsReverse : ""
           }`}
         >
-          <PlayIcon
-            fill="#ebebeb"
-            className={`${styles.icon} ${styles.iconStart} ${
-              projectedSeekInSeconds < 0 ? styles.iconBackward : ""
-            }`}
-            testId="playIcon"
-          />
-          <PlayIcon
-            fill="#ebebeb"
-            className={`${styles.icon} ${styles.iconMiddle} ${
-              projectedSeekInSeconds < 0 ? styles.iconBackward : ""
-            }`}
-          />
-          <PlayIcon
-            fill="#ebebeb"
-            className={`${styles.icon} ${styles.iconEnd} ${
-              projectedSeekInSeconds < 0 ? styles.iconBackward : ""
-            }`}
-          />
+          {[0, 1, 2].map((element) => (
+            <PlayIcon
+              fill="#ebebeb"
+              className={`${styles.icon} ${
+                projectedSeekInSeconds < 0 ? styles.iconBackward : ""
+              }`}
+              testId="playIcon"
+              key={element}
+            />
+          ))}
         </div>
         <span className={styles.seekText}>{formattedSeconds}</span>
       </div>

--- a/features/players/components/SeekIndicator.tsx
+++ b/features/players/components/SeekIndicator.tsx
@@ -1,0 +1,18 @@
+import styles from "features/players/components/styles/SeekIndicator.module.css";
+
+interface SeekIndicatorProps {
+  projectedSeekInSeconds: number;
+}
+
+export const SeekIndicator = ({
+  projectedSeekInSeconds,
+}: SeekIndicatorProps) => {
+  // TODO: Seek duration conversion using module operator
+  // TODO: Customise ariaLabel depending on forward/backward seek
+
+  return (
+    <div className="" aria-label="">
+      {projectedSeekInSeconds}
+    </div>
+  );
+};

--- a/features/players/components/SeekIndicator.tsx
+++ b/features/players/components/SeekIndicator.tsx
@@ -11,11 +11,12 @@ export const SeekIndicator = ({
   const formattedSeconds = convertSecondsToHumanReadable(
     projectedSeekInSeconds
   );
+
   return (
     <div
-      className={
+      className={`${
         projectedSeekInSeconds < 0 ? styles.seekBackward : styles.seekForward
-      }
+      } ${styles.container}`}
       aria-label={
         projectedSeekInSeconds < 0
           ? `Skip backward ${formattedSeconds}`

--- a/features/players/components/SeekIndicator.tsx
+++ b/features/players/components/SeekIndicator.tsx
@@ -1,5 +1,6 @@
 import styles from "features/players/components/styles/SeekIndicator.module.css";
 import PlayIcon from "icons/PlayIcon";
+import { useEffect, useRef } from "react";
 import { convertSecondsToHumanReadable } from "utils/videoDurationConversion";
 
 interface SeekIndicatorProps {
@@ -26,18 +27,28 @@ export const SeekIndicator = ({
       role="status"
     >
       <div className={styles.innerContent}>
-        <div className={styles.iconContainer}>
+        <div
+          className={`${styles.iconContainer} ${
+            projectedSeekInSeconds < 0 ? styles.iconsReverse : ""
+          }`}
+        >
           <PlayIcon
             fill="#ebebeb"
-            className={`${styles.icon} ${styles.iconStart}`}
+            className={`${styles.icon} ${styles.iconStart} ${
+              projectedSeekInSeconds < 0 ? styles.iconBackward : ""
+            }`}
           />
           <PlayIcon
             fill="#ebebeb"
-            className={`${styles.icon} ${styles.iconMiddle}`}
+            className={`${styles.icon} ${styles.iconMiddle} ${
+              projectedSeekInSeconds < 0 ? styles.iconBackward : ""
+            }`}
           />
           <PlayIcon
             fill="#ebebeb"
-            className={`${styles.icon} ${styles.iconEnd}`}
+            className={`${styles.icon} ${styles.iconEnd} ${
+              projectedSeekInSeconds < 0 ? styles.iconBackward : ""
+            }`}
           />
         </div>
         <span className={styles.seekText}>{formattedSeconds}</span>

--- a/features/players/components/SeekIndicator.tsx
+++ b/features/players/components/SeekIndicator.tsx
@@ -1,4 +1,5 @@
 import styles from "features/players/components/styles/SeekIndicator.module.css";
+import PlayIcon from "icons/PlayIcon";
 import { convertSecondsToHumanReadable } from "utils/videoDurationConversion";
 
 interface SeekIndicatorProps {
@@ -24,7 +25,23 @@ export const SeekIndicator = ({
       }
       role="status"
     >
-      {formattedSeconds}
+      <div className={styles.innerContent}>
+        <div className={styles.iconContainer}>
+          <PlayIcon
+            fill="#ebebeb"
+            className={`${styles.icon} ${styles.iconStart}`}
+          />
+          <PlayIcon
+            fill="#ebebeb"
+            className={`${styles.icon} ${styles.iconMiddle}`}
+          />
+          <PlayIcon
+            fill="#ebebeb"
+            className={`${styles.icon} ${styles.iconEnd}`}
+          />
+        </div>
+        <span className={styles.seekText}>{formattedSeconds}</span>
+      </div>
     </div>
   );
 };

--- a/features/players/components/SeekIndicator.tsx
+++ b/features/players/components/SeekIndicator.tsx
@@ -1,4 +1,5 @@
 import styles from "features/players/components/styles/SeekIndicator.module.css";
+import { convertSecondsToHumanReadable } from "utils/videoDurationConversion";
 
 interface SeekIndicatorProps {
   projectedSeekInSeconds: number;
@@ -7,12 +8,22 @@ interface SeekIndicatorProps {
 export const SeekIndicator = ({
   projectedSeekInSeconds,
 }: SeekIndicatorProps) => {
-  // TODO: Seek duration conversion using module operator
-  // TODO: Customise ariaLabel depending on forward/backward seek
-
+  const formattedSeconds = convertSecondsToHumanReadable(
+    projectedSeekInSeconds
+  );
   return (
-    <div className="" aria-label="">
-      {projectedSeekInSeconds}
+    <div
+      className={
+        projectedSeekInSeconds < 0 ? styles.seekBackward : styles.seekForward
+      }
+      aria-label={
+        projectedSeekInSeconds < 0
+          ? `Skip backward ${formattedSeconds}`
+          : `Skip forward ${formattedSeconds}`
+      }
+      role="status"
+    >
+      {formattedSeconds}
     </div>
   );
 };

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -10,6 +10,7 @@ import { useSeek } from "../hooks/useSeek";
 import { VideoControlIndicator } from "./VideoControlIndicator";
 import { useControlIndicators } from "../hooks/useControlIndicators";
 import { VolumeLevelIndicator } from "./VolumeLevelIndicator";
+import { SeekIndicator } from "./SeekIndicator";
 
 interface VideoPlayerProps {
   player: Player | null;
@@ -23,7 +24,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
     signalUserActivity,
     setLockUserActive,
   } = useUserActivity();
-  const { scheduleSeek, projectedTime } = useSeek(player);
+  const { scheduleSeek, projectedTime, seekAmount } = useSeek(player);
   const {
     showControlIndicator,
     triggerControlIndication,
@@ -91,6 +92,12 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
       wrapperRef.current.focus();
     }
   };
+
+  React.useEffect(() => {
+    addEventListener("performSeek", () => {
+      console.log("Seek performed");
+    });
+  }, []);
 
   // A global keypress handler to allow the user to control the video regardless of where they are on the page.
   React.useEffect(() => {
@@ -240,6 +247,11 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
         {showVolumeLevelIndicator && player && (
           <VolumeLevelIndicator currentVolume={player.getVolume()} />
         )}
+
+        {seekAmount && player && (
+          <SeekIndicator projectedSeekInSeconds={seekAmount} />
+        )}
+
         <VideoControlIndicator
           ariaLabel={controlAction}
           controlAction={controlAction}

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -248,9 +248,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
           <VolumeLevelIndicator currentVolume={player.getVolume()} />
         )}
 
-        {seekAmount && player && (
-          <SeekIndicator projectedSeekInSeconds={seekAmount} />
-        )}
+        {seekAmount && <SeekIndicator projectedSeekInSeconds={seekAmount} />}
 
         <VideoControlIndicator
           ariaLabel={controlAction}

--- a/features/players/components/__tests__/SeekIndicator.test.tsx
+++ b/features/players/components/__tests__/SeekIndicator.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import { SeekIndicator } from "../SeekIndicator";
+
+describe("Volume level indicator UI", () => {
+  it("Shows correct volume percentage", () => {
+    render(<SeekIndicator projectedSeekInSeconds={5} />);
+    const volumeLevel = screen.getByText("50%");
+    expect(volumeLevel).toBeInTheDocument();
+  });
+
+  it("Has correct accessible description", () => {
+    render(<SeekIndicator projectedSeekInSeconds={30} />);
+    const volumeLabel = screen.getByLabelText("Volume level 50%");
+    expect(volumeLabel).toBeInTheDocument();
+  });
+});

--- a/features/players/components/__tests__/SeekIndicator.test.tsx
+++ b/features/players/components/__tests__/SeekIndicator.test.tsx
@@ -20,15 +20,25 @@ describe("Seek indicator UI", () => {
     expect(indicator).toBeInTheDocument();
   });
 
-  it("Renders right side indicator and facing icon for forward seek", () => {
+  it("Renders forward facing classes for forward seek", () => {
     render(<SeekIndicator projectedSeekInSeconds={10} />);
     const indicator = screen.getByRole("status");
+    const playIcons = screen.getAllByTestId("playIcon");
+
     expect(indicator).toHaveClass("seekForward");
+    playIcons.forEach((icon) => {
+      expect(icon).not.toHaveClass("iconBackward");
+    });
   });
 
-  it("Renders left side indicator and facing icon for backward seek", () => {
+  it("Renders backward facing classes for backward seek", () => {
     render(<SeekIndicator projectedSeekInSeconds={-10} />);
     const indicator = screen.getByRole("status");
+    const playIcons = screen.getAllByTestId("playIcon");
+
     expect(indicator).toHaveClass("seekBackward");
+    playIcons.forEach((icon) => {
+      expect(icon).toHaveClass("iconBackward");
+    });
   });
 });

--- a/features/players/components/__tests__/SeekIndicator.test.tsx
+++ b/features/players/components/__tests__/SeekIndicator.test.tsx
@@ -2,15 +2,9 @@ import { render, screen } from "@testing-library/react";
 import { SeekIndicator } from "../SeekIndicator";
 
 describe("Seek indicator UI", () => {
-  it("Shows correct number of seconds to seek (for seek < 1 min)", () => {
+  it("Shows converted seek number", () => {
     render(<SeekIndicator projectedSeekInSeconds={10} />);
     const indicator = screen.getByText("10 seconds");
-    expect(indicator).toBeInTheDocument();
-  });
-
-  it("Shows correct number of minutes to seek (for seek > 1 min)", () => {
-    render(<SeekIndicator projectedSeekInSeconds={300} />);
-    const indicator = screen.getByText("5 minutes");
     expect(indicator).toBeInTheDocument();
   });
 

--- a/features/players/components/__tests__/SeekIndicator.test.tsx
+++ b/features/players/components/__tests__/SeekIndicator.test.tsx
@@ -1,16 +1,34 @@
 import { render, screen } from "@testing-library/react";
 import { SeekIndicator } from "../SeekIndicator";
 
-describe("Volume level indicator UI", () => {
-  it("Shows correct volume percentage", () => {
-    render(<SeekIndicator projectedSeekInSeconds={5} />);
-    const volumeLevel = screen.getByText("50%");
-    expect(volumeLevel).toBeInTheDocument();
+describe("Seek indicator UI", () => {
+  it.todo("Shows correct number of seconds to seek (for seek < 1 min)", () => {
+    render(<SeekIndicator projectedSeekInSeconds={10} />);
   });
 
-  it("Has correct accessible description", () => {
-    render(<SeekIndicator projectedSeekInSeconds={30} />);
-    const volumeLabel = screen.getByLabelText("Volume level 50%");
-    expect(volumeLabel).toBeInTheDocument();
+  it.todo("Shows correct number of minutes to seek (for seek > 1 min)", () => {
+    render(<SeekIndicator projectedSeekInSeconds={300} />);
   });
+
+  it.todo("Has correct accessible description for seeking forward", () => {
+    render(<SeekIndicator projectedSeekInSeconds={30} />);
+  });
+
+  it.todo("Has correct accessible description for seeking backward", () => {
+    render(<SeekIndicator projectedSeekInSeconds={-30} />);
+  });
+
+  it.todo(
+    "Renders right side indicator and facing icon for forward seek",
+    () => {
+      render(<SeekIndicator projectedSeekInSeconds={30} />);
+    }
+  );
+
+  it.todo(
+    "Renders left side indicator and facing icon for backward seek",
+    () => {
+      render(<SeekIndicator projectedSeekInSeconds={-30} />);
+    }
+  );
 });

--- a/features/players/components/__tests__/SeekIndicator.test.tsx
+++ b/features/players/components/__tests__/SeekIndicator.test.tsx
@@ -2,33 +2,39 @@ import { render, screen } from "@testing-library/react";
 import { SeekIndicator } from "../SeekIndicator";
 
 describe("Seek indicator UI", () => {
-  it.todo("Shows correct number of seconds to seek (for seek < 1 min)", () => {
+  it("Shows correct number of seconds to seek (for seek < 1 min)", () => {
     render(<SeekIndicator projectedSeekInSeconds={10} />);
+    const indicator = screen.getByText("10 seconds");
+    expect(indicator).toBeInTheDocument();
   });
 
-  it.todo("Shows correct number of minutes to seek (for seek > 1 min)", () => {
+  it("Shows correct number of minutes to seek (for seek > 1 min)", () => {
     render(<SeekIndicator projectedSeekInSeconds={300} />);
+    const indicator = screen.getByText("5 minutes");
+    expect(indicator).toBeInTheDocument();
   });
 
-  it.todo("Has correct accessible description for seeking forward", () => {
-    render(<SeekIndicator projectedSeekInSeconds={30} />);
+  it("Has correct accessible description for seeking forward", () => {
+    render(<SeekIndicator projectedSeekInSeconds={10} />);
+    const indicator = screen.getByLabelText("Skip forward 10 seconds");
+    expect(indicator).toBeInTheDocument();
   });
 
-  it.todo("Has correct accessible description for seeking backward", () => {
-    render(<SeekIndicator projectedSeekInSeconds={-30} />);
+  it("Has correct accessible description for seeking backward", () => {
+    render(<SeekIndicator projectedSeekInSeconds={-10} />);
+    const indicator = screen.getByLabelText("Skip backward 10 seconds");
+    expect(indicator).toBeInTheDocument();
   });
 
-  it.todo(
-    "Renders right side indicator and facing icon for forward seek",
-    () => {
-      render(<SeekIndicator projectedSeekInSeconds={30} />);
-    }
-  );
+  it("Renders right side indicator and facing icon for forward seek", () => {
+    render(<SeekIndicator projectedSeekInSeconds={10} />);
+    const indicator = screen.getByRole("status");
+    expect(indicator).toHaveClass("seekForward");
+  });
 
-  it.todo(
-    "Renders left side indicator and facing icon for backward seek",
-    () => {
-      render(<SeekIndicator projectedSeekInSeconds={-30} />);
-    }
-  );
+  it("Renders left side indicator and facing icon for backward seek", () => {
+    render(<SeekIndicator projectedSeekInSeconds={-10} />);
+    const indicator = screen.getByRole("status");
+    expect(indicator).toHaveClass("seekBackward");
+  });
 });

--- a/features/players/components/__tests__/VideoPlayer.test.tsx
+++ b/features/players/components/__tests__/VideoPlayer.test.tsx
@@ -380,4 +380,15 @@ describe("Video player control indicators", () => {
 
     expect(indicator).not.toBeInTheDocument();
   });
+
+  it.todo("Shows seek indicator when seeking with the keyboard", async () => {
+    render(<VideoPlayer player={player} />);
+  });
+
+  it.todo(
+    "Shows seek indicator when seeking with the clickable controls",
+    async () => {
+      render(<VideoPlayer player={player} />);
+    }
+  );
 });

--- a/features/players/components/__tests__/VideoPlayer.test.tsx
+++ b/features/players/components/__tests__/VideoPlayer.test.tsx
@@ -381,14 +381,37 @@ describe("Video player control indicators", () => {
     expect(indicator).not.toBeInTheDocument();
   });
 
-  it.todo("Shows seek indicator when seeking with the keyboard", async () => {
-    render(<VideoPlayer player={player} />);
-  });
+  it.todo(
+    "Shows correct seek indicator when seeking with the keyboard",
+    async () => {
+      render(<VideoPlayer player={player} />);
+      const wrapper = screen.getByTestId("wrapper");
+
+      // First focus the wrapper to ensure the keypress is captured correctly
+      wrapper.focus();
+      await userEvent.keyboard("[ArrowRight]");
+
+      const indicator = screen.getByRole("status");
+      expect(indicator).toBeInTheDocument();
+      expect(indicator).toHaveClass("seekForward");
+    }
+  );
 
   it.todo(
     "Shows seek indicator when seeking with the clickable controls",
     async () => {
       render(<VideoPlayer player={player} />);
+
+      // First hover the relevant div to trigger user activity/controls to show
+      const overlay = screen.getByTestId("overlay");
+      await userEvent.hover(overlay);
+
+      const seekBtn = screen.getByLabelText(/skip forward one minute/i);
+      await userEvent.click(seekBtn);
+
+      const indicator = screen.getByRole("status");
+      expect(indicator).toBeInTheDocument();
+      expect(indicator).toHaveClass("seekForward");
     }
   );
 });

--- a/features/players/components/__tests__/VideoPlayer.test.tsx
+++ b/features/players/components/__tests__/VideoPlayer.test.tsx
@@ -391,21 +391,5 @@ describe("Video player control indicators", () => {
 
     const indicator = screen.getByText("10 seconds");
     expect(indicator).toBeInTheDocument();
-    expect(indicator).toHaveClass("seekForward");
-  });
-
-  it("Shows seek indicator when seeking with the clickable controls", async () => {
-    render(<VideoPlayer player={player} />);
-
-    // First hover the relevant div to trigger user activity/controls to show
-    const overlay = screen.getByTestId("overlay");
-    await userEvent.hover(overlay);
-
-    const seekBtn = screen.getByLabelText(/skip forward one minute/i);
-    await userEvent.click(seekBtn);
-
-    const indicator = screen.getByText("1 minute");
-    expect(indicator).toBeInTheDocument();
-    expect(indicator).toHaveClass("seekForward");
   });
 });

--- a/features/players/components/__tests__/VideoPlayer.test.tsx
+++ b/features/players/components/__tests__/VideoPlayer.test.tsx
@@ -381,37 +381,31 @@ describe("Video player control indicators", () => {
     expect(indicator).not.toBeInTheDocument();
   });
 
-  it.todo(
-    "Shows correct seek indicator when seeking with the keyboard",
-    async () => {
-      render(<VideoPlayer player={player} />);
-      const wrapper = screen.getByTestId("wrapper");
+  it("Shows correct seek indicator when seeking with the keyboard", async () => {
+    render(<VideoPlayer player={player} />);
+    const wrapper = screen.getByTestId("wrapper");
 
-      // First focus the wrapper to ensure the keypress is captured correctly
-      wrapper.focus();
-      await userEvent.keyboard("[ArrowRight]");
+    // First focus the wrapper to ensure the keypress is captured correctly
+    wrapper.focus();
+    await userEvent.keyboard("[ArrowRight]");
 
-      const indicator = screen.getByRole("status");
-      expect(indicator).toBeInTheDocument();
-      expect(indicator).toHaveClass("seekForward");
-    }
-  );
+    const indicator = screen.getByText("10 seconds");
+    expect(indicator).toBeInTheDocument();
+    expect(indicator).toHaveClass("seekForward");
+  });
 
-  it.todo(
-    "Shows seek indicator when seeking with the clickable controls",
-    async () => {
-      render(<VideoPlayer player={player} />);
+  it("Shows seek indicator when seeking with the clickable controls", async () => {
+    render(<VideoPlayer player={player} />);
 
-      // First hover the relevant div to trigger user activity/controls to show
-      const overlay = screen.getByTestId("overlay");
-      await userEvent.hover(overlay);
+    // First hover the relevant div to trigger user activity/controls to show
+    const overlay = screen.getByTestId("overlay");
+    await userEvent.hover(overlay);
 
-      const seekBtn = screen.getByLabelText(/skip forward one minute/i);
-      await userEvent.click(seekBtn);
+    const seekBtn = screen.getByLabelText(/skip forward one minute/i);
+    await userEvent.click(seekBtn);
 
-      const indicator = screen.getByRole("status");
-      expect(indicator).toBeInTheDocument();
-      expect(indicator).toHaveClass("seekForward");
-    }
-  );
+    const indicator = screen.getByText("1 minute");
+    expect(indicator).toBeInTheDocument();
+    expect(indicator).toHaveClass("seekForward");
+  });
 });

--- a/features/players/components/styles/SeekIndicator.module.css
+++ b/features/players/components/styles/SeekIndicator.module.css
@@ -9,8 +9,8 @@
 .container {
   pointer-events: none;
   background-color: rgba(0, 0, 0, 0.5);
-  height: 7rem;
-  width: 7rem;
+  height: 7.25rem;
+  width: 7.25rem;
   color: white;
   border-radius: 100%;
   display: flex;
@@ -59,7 +59,7 @@
 }
 
 .seekText {
-  font-size: 0.7rem;
+  font-size: 0.8rem;
   font-weight: 500;
 }
 

--- a/features/players/components/styles/SeekIndicator.module.css
+++ b/features/players/components/styles/SeekIndicator.module.css
@@ -33,25 +33,20 @@
   padding: 0;
   margin: 0 -0.1rem;
   line-height: 0;
-  animation: infinite 1800ms ease fade-in-out;
-  opacity: 0;
+  animation: infinite 1100ms ease fade-in-out;
+  opacity: 0.1;
+}
+
+.icon:nth-child(2) {
+  animation-delay: 100ms;
+}
+
+.icon:nth-child(3) {
+  animation-delay: 300ms;
 }
 
 .iconBackward {
   transform: rotate(180deg);
-}
-
-.iconStart {
-}
-
-.iconMiddle {
-  animation-delay: 200ms;
-  opacity: 0.1;
-}
-
-.iconEnd {
-  animation-delay: 400ms;
-  opacity: 0.1;
 }
 
 .iconContainer {
@@ -72,8 +67,9 @@
   0%,
   40%,
   100% {
-    opacity: 0;
+    opacity: 0.2;
   }
+
   20% {
     opacity: 1;
   }

--- a/features/players/components/styles/SeekIndicator.module.css
+++ b/features/players/components/styles/SeekIndicator.module.css
@@ -3,3 +3,19 @@
 
 .seekBackward {
 }
+
+.container {
+  pointer-events: none;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 3rem;
+  width: 5rem;
+  color: white;
+  font-size: 1.25rem;
+  border-radius: 5px;
+  position: absolute;
+  top: calc(12.5%);
+  left: calc(50% - 2.5rem);
+}

--- a/features/players/components/styles/SeekIndicator.module.css
+++ b/features/players/components/styles/SeekIndicator.module.css
@@ -33,8 +33,8 @@
   padding: 0;
   margin: 0 -0.1rem;
   line-height: 0;
-  animation: infinite 900ms ease fade-in-out;
-  animation-delay: 1000ms;
+  animation: infinite 1800ms ease fade-in-out;
+  opacity: 0;
 }
 
 .iconBackward {
@@ -42,16 +42,15 @@
 }
 
 .iconStart {
-  animation-delay: 100ms;
 }
 
 .iconMiddle {
-  animation-delay: 300ms;
+  animation-delay: 200ms;
   opacity: 0.1;
 }
 
 .iconEnd {
-  animation-delay: 500ms;
+  animation-delay: 400ms;
   opacity: 0.1;
 }
 
@@ -70,15 +69,12 @@
 }
 
 @keyframes fade-in-out {
-  0% {
-    opacity: 0.9;
-  }
-
-  50% {
-    opacity: 0.2;
-  }
-
+  0%,
+  40%,
   100% {
+    opacity: 0;
+  }
+  20% {
     opacity: 1;
   }
 }

--- a/features/players/components/styles/SeekIndicator.module.css
+++ b/features/players/components/styles/SeekIndicator.module.css
@@ -20,6 +20,13 @@
   top: calc(50% - 3rem);
 }
 
+.innerContent {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+}
+
 .icon {
   height: 1.6rem;
   width: 1.6rem;
@@ -43,6 +50,12 @@
 
 .iconContainer {
   display: flex;
+  padding-bottom: 0.25rem;
+}
+
+.seekText {
+  font-size: 0.7rem;
+  font-weight: 500;
 }
 
 @keyframes fade-in-out {

--- a/features/players/components/styles/SeekIndicator.module.css
+++ b/features/players/components/styles/SeekIndicator.module.css
@@ -31,7 +31,7 @@
   height: 1.5rem;
   width: 1.5rem;
   padding: 0;
-  margin: 0 -0.05rem;
+  margin: 0 -0.1rem;
   line-height: 0;
   animation: infinite 900ms ease fade-in-out;
   animation-delay: 1000ms;

--- a/features/players/components/styles/SeekIndicator.module.css
+++ b/features/players/components/styles/SeekIndicator.module.css
@@ -1,0 +1,5 @@
+.seekForward {
+}
+
+.seekBackward {
+}

--- a/features/players/components/styles/SeekIndicator.module.css
+++ b/features/players/components/styles/SeekIndicator.module.css
@@ -19,3 +19,42 @@
   position: absolute;
   top: calc(50% - 3rem);
 }
+
+.icon {
+  height: 1.6rem;
+  width: 1.6rem;
+  padding: 0;
+  margin: 0 -0.1rem;
+  line-height: 0;
+  animation: infinite 900ms ease fade-in-out;
+}
+
+.iconStart {
+  animation-delay: 100ms;
+}
+
+.iconMiddle {
+  animation-delay: 200ms;
+}
+
+.iconEnd {
+  animation-delay: 300ms;
+}
+
+.iconContainer {
+  display: flex;
+}
+
+@keyframes fade-in-out {
+  0% {
+    opacity: 0.2;
+  }
+
+  50% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0.1;
+  }
+}

--- a/features/players/components/styles/SeekIndicator.module.css
+++ b/features/players/components/styles/SeekIndicator.module.css
@@ -1,21 +1,21 @@
 .seekForward {
+  right: calc(10%);
 }
 
 .seekBackward {
+  left: calc(10%);
 }
 
 .container {
   pointer-events: none;
   background-color: rgba(0, 0, 0, 0.5);
+  height: 6rem;
+  width: 6rem;
+  color: white;
+  border-radius: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 3rem;
-  width: 5rem;
-  color: white;
-  font-size: 1.25rem;
-  border-radius: 5px;
   position: absolute;
-  top: calc(12.5%);
-  left: calc(50% - 2.5rem);
+  top: calc(50% - 3rem);
 }

--- a/features/players/components/styles/SeekIndicator.module.css
+++ b/features/players/components/styles/SeekIndicator.module.css
@@ -9,8 +9,8 @@
 .container {
   pointer-events: none;
   background-color: rgba(0, 0, 0, 0.5);
-  height: 6rem;
-  width: 6rem;
+  height: 7rem;
+  width: 7rem;
   color: white;
   border-radius: 100%;
   display: flex;
@@ -28,12 +28,17 @@
 }
 
 .icon {
-  height: 1.6rem;
-  width: 1.6rem;
+  height: 1.5rem;
+  width: 1.5rem;
   padding: 0;
-  margin: 0 -0.1rem;
+  margin: 0 -0.05rem;
   line-height: 0;
   animation: infinite 900ms ease fade-in-out;
+  animation-delay: 1000ms;
+}
+
+.iconBackward {
+  transform: rotate(180deg);
 }
 
 .iconStart {
@@ -41,16 +46,22 @@
 }
 
 .iconMiddle {
-  animation-delay: 200ms;
+  animation-delay: 300ms;
+  opacity: 0.1;
 }
 
 .iconEnd {
-  animation-delay: 300ms;
+  animation-delay: 500ms;
+  opacity: 0.1;
 }
 
 .iconContainer {
   display: flex;
-  padding-bottom: 0.25rem;
+  padding-bottom: 0.5rem;
+}
+
+.iconsReverse {
+  flex-direction: row-reverse;
 }
 
 .seekText {
@@ -60,14 +71,14 @@
 
 @keyframes fade-in-out {
   0% {
-    opacity: 0.2;
+    opacity: 0.9;
   }
 
   50% {
-    opacity: 1;
+    opacity: 0.2;
   }
 
   100% {
-    opacity: 0.1;
+    opacity: 1;
   }
 }

--- a/features/players/hooks/useSeek.tsx
+++ b/features/players/hooks/useSeek.tsx
@@ -6,12 +6,21 @@ export const useSeek = (player: Player | null) => {
   // The currently projected time (in seconds) that the player should be at once the currently queued seek completes.
   // When this is not null, it implies we are currently performing a seek() call.
   const [projectedTime, setProjectedTime] = React.useState<null | number>(null);
+  // This state is used to help manage indicators that require the requested seek amount, not the updated projected time
+  const [seekAmount, setSeekAmount] = React.useState<null | number>(null);
   const seekTimer = React.useRef<NodeJS.Timeout | null>(null);
 
   const scheduleSeek = React.useCallback(
     (timeToSkipInSeconds: number) => {
       if (player) {
         clearTimeout(seekTimer.current as NodeJS.Timeout);
+
+        if (!seekAmount) {
+          setSeekAmount(timeToSkipInSeconds);
+        } else {
+          setSeekAmount(timeToSkipInSeconds + seekAmount);
+        }
+
         const currentTime = player.getCurrentTime();
         let updatedProjection: number;
         if (projectedTime) {
@@ -28,7 +37,7 @@ export const useSeek = (player: Player | null) => {
         }, 500);
       }
     },
-    [player, projectedTime]
+    [player, projectedTime, seekAmount]
   );
 
   React.useEffect(() => {
@@ -36,6 +45,7 @@ export const useSeek = (player: Player | null) => {
       // Ensure projectedTime is reset to null to avoid infinite loop seeking or video freezing at fixed time
       player.addEventListener("seek", () => {
         setProjectedTime(null);
+        setSeekAmount(null);
       });
     }
   }, [player]);
@@ -43,5 +53,6 @@ export const useSeek = (player: Player | null) => {
   return {
     scheduleSeek,
     projectedTime,
+    seekAmount,
   };
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,3 +1,4 @@
+import { SeekIndicator } from "features/players/components/SeekIndicator";
 import Head from "next/head";
 
 export default function Home() {
@@ -7,6 +8,7 @@ export default function Home() {
         <title>Resports</title>
       </Head>
       <h2>Home</h2>
+      <SeekIndicator projectedSeekInSeconds={10} />
     </>
   );
 }

--- a/utils/__tests__/videoDurationConversion.test.ts
+++ b/utils/__tests__/videoDurationConversion.test.ts
@@ -188,7 +188,7 @@ describe("Seconds to human readable conversions", () => {
   });
 
   it("Converts 60 seconds to single minute", () => {
-    expect(convertSecondsToHumanReadable(300)).toBe("1 minute");
+    expect(convertSecondsToHumanReadable(60)).toBe("1 minute");
   });
 
   it("Converts > 60 seconds to minutes", () => {

--- a/utils/__tests__/videoDurationConversion.test.ts
+++ b/utils/__tests__/videoDurationConversion.test.ts
@@ -1,5 +1,6 @@
 import {
   convertISOToSeconds,
+  convertSecondsToHumanReadable,
   convertTwitchVideoDuration,
   convertYouTubeVideoDuration,
   formatElapsedTime,
@@ -174,5 +175,31 @@ describe("Elapsed duration conversions", () => {
 
   it("Handles negative duration inputs (from backwards skipping)", () => {
     expect(formatElapsedTime(-600)).toBe("0:00");
+  });
+});
+
+describe("Seconds to human readable conversions", () => {
+  it("Handles zero second input correctly", () => {
+    expect(convertSecondsToHumanReadable(0)).toBe("0 seconds");
+  });
+
+  it("Handles < 60 second input correctly", () => {
+    expect(convertSecondsToHumanReadable(10)).toBe("10 seconds");
+  });
+
+  it("Converts 60 seconds to single minute", () => {
+    expect(convertSecondsToHumanReadable(300)).toBe("1 minute");
+  });
+
+  it("Converts > 60 seconds to minutes", () => {
+    expect(convertSecondsToHumanReadable(300)).toBe("5 minutes");
+  });
+
+  it("Handles large numbers of seconds (up to 12 hours equivalent)", () => {
+    expect(convertSecondsToHumanReadable(43200)).toBe("720 minutes");
+  });
+
+  it("Handles negative number inputs", () => {
+    expect(convertSecondsToHumanReadable(-10)).toBe("10 seconds");
   });
 });

--- a/utils/videoDurationConversion.ts
+++ b/utils/videoDurationConversion.ts
@@ -256,7 +256,7 @@ export const formatElapsedTime = (elapsedTimeInSeconds: number) => {
   return `${formattedHours}${formattedMinutes}:${formattedSeconds}`;
 };
 
-// Convert seconds to the human readable "x seconds" or "x minutes". Support is not required for hours at this stage, as this is only used in seeking videos forward/back
+// Convert seconds to the human readable "x seconds" or "x minutes". Support is not required for hours at this stage, as this is only used in seeking videos forward/back.
 export const convertSecondsToHumanReadable = (numberOfSeconds: number) => {
   const minutes = Math.floor(Math.abs(numberOfSeconds) / 60);
   const seconds = Math.abs(numberOfSeconds);

--- a/utils/videoDurationConversion.ts
+++ b/utils/videoDurationConversion.ts
@@ -255,3 +255,8 @@ export const formatElapsedTime = (elapsedTimeInSeconds: number) => {
   // Note the colon only exists between mins/sec as it needs full omission for zero hours
   return `${formattedHours}${formattedMinutes}:${formattedSeconds}`;
 };
+
+// Convert seconds to the human readable "x seconds" or "x minutes". Support is not required for hours at this stage, as this is only used in seeking videos forward/back
+export const convertSecondsToHumanReadable = (numberOfSeconds: number) => {
+  return;
+};

--- a/utils/videoDurationConversion.ts
+++ b/utils/videoDurationConversion.ts
@@ -258,5 +258,14 @@ export const formatElapsedTime = (elapsedTimeInSeconds: number) => {
 
 // Convert seconds to the human readable "x seconds" or "x minutes". Support is not required for hours at this stage, as this is only used in seeking videos forward/back
 export const convertSecondsToHumanReadable = (numberOfSeconds: number) => {
-  return;
+  const minutes = Math.floor(Math.abs(numberOfSeconds) / 60);
+  const seconds = Math.abs(numberOfSeconds);
+
+  if (minutes === 0) {
+    return `${seconds} seconds`;
+  } else if (minutes === 1) {
+    return "1 minute";
+  } else {
+    return `${minutes} minutes`;
+  }
 };


### PR DESCRIPTION
This PR adds a visible indicator when the user seeks forward or backward on the video. It meets the following acceptance criteria:

- A separate side indicator is shown when the user performs a seek with either mouse or keyboard.
- It should replicate YT design in virtually every way, but with dynamic numbers.
- The indicator should be on the right side for seek forward and left for seek backward.
- The accessibility should be dynamic in terms of announcing seek amount.
- There is unit test coverage.