### PR TITLE
Enlarge indicator when in full screen mode

### DIFF
--- a/features/players/components/VideoControlIndicator.tsx
+++ b/features/players/components/VideoControlIndicator.tsx
@@ -79,7 +79,9 @@ export const VideoControlIndicator = ({
 
   return (
     <div
-      className={`${styles.container}`}
+      className={`${styles.container} ${
+        document.fullscreenElement ? styles.large : ""
+      }`}
       role="status"
       aria-label={
         ariaLabelRequired() && ariaLabel !== null ? ariaLabel : undefined
@@ -87,7 +89,13 @@ export const VideoControlIndicator = ({
       ref={indicator}
       onAnimationEnd={handleAnimationEnd}
     >
-      <div className={styles.iconWrapper}>{selectIcon(controlAction)}</div>
+      <div
+        className={`${styles.iconWrapper} ${
+          document.fullscreenElement ? styles.iconLarge : ""
+        }`}
+      >
+        {selectIcon(controlAction)}
+      </div>
     </div>
   );
 };

--- a/features/players/components/styles/VideoControlIndicator.module.css
+++ b/features/players/components/styles/VideoControlIndicator.module.css
@@ -1,8 +1,8 @@
 .container {
   pointer-events: none;
   background-color: rgba(0, 0, 0, 0.5);
-  height: 3.25rem;
-  width: 3.25rem;
+  height: 3.4rem;
+  width: 3.4rem;
   border-radius: 100%;
   display: flex;
   align-items: center;
@@ -13,9 +13,19 @@
   left: calc(50% - 1.625rem);
 }
 
+.large {
+  height: 5rem;
+  width: 5rem;
+}
+
 .iconWrapper {
   width: 2rem;
   height: 2rem;
+}
+
+.iconLarge {
+  height: 2.25rem;
+  width: 2.25rem;
 }
 
 .triggerAnimation {


### PR DESCRIPTION
Currently the control indicator is a fixed size regardless of player size. When in full screen mode, the indicator feels too small as a result. This PR increases the size for full screen mode only. It meets the following acceptance criteria:- 
- The control indicator should be able to detect full screen mode, and switch to a larger size. 
- The size change should automatically toggle in and out of full screen mode. 