### PR TITLE
Volume muting adjustments

### DIFF
--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -267,6 +267,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
         >
           <VideoControls
             player={player}
+            setPlayerMuted={setPlayerMuted}
             playerPaused={playerPaused}
             toggleFullscreen={() => toggleFullscreen(wrapperRef.current)}
             toggleTheaterMode={toggleTheaterMode}

--- a/features/players/components/__tests__/VideoControls.test.tsx
+++ b/features/players/components/__tests__/VideoControls.test.tsx
@@ -9,6 +9,7 @@ const playerMock = {
   getCurrentTime: () => 1,
   isMuted: () => false,
   getVolume: jest.fn,
+  getMuted: () => true,
   getQualities: () => [
     {
       name: "Auto",

--- a/features/players/components/__tests__/VideoPlayer.test.tsx
+++ b/features/players/components/__tests__/VideoPlayer.test.tsx
@@ -13,7 +13,7 @@ const setMutedMock = jest.fn();
 
 const playerWrapperPlaying: PlayerClass = {
   getCurrentTime: () => 100,
-  getMuted: () => false,
+  getMuted: () => true,
   setMuted: setMutedMock,
   isPaused: () => false,
   play: playMock,
@@ -440,27 +440,27 @@ describe("Volume and muting control", () => {
     expect(muteButton).toBeInTheDocument();
   });
 
-  it("Volume slider retains previous volume when unmuted", async () => {
-    // const player = new Player(playerWrapperUnmuted);
-    render(<VideoPlayer player={player} />);
+  // it("Volume slider retains previous volume when unmuted", async () => {
+  //   // const player = new Player(playerWrapperUnmuted);
+  //   render(<VideoPlayer player={player} />);
 
-    // Volume slider should be initialising at 50 volume
-    const volumeSlider = screen.getByLabelText("Volume");
-    expect(volumeSlider).toHaveValue("50");
+  //   // Volume slider should be initialising at 50 volume
+  //   const volumeSlider = screen.getByLabelText("Volume");
+  //   expect(volumeSlider).toHaveValue("50");
 
-    // Manually set the volume using the slider
-    fireEvent.change(volumeSlider, { target: { value: 20 } });
-    expect(volumeSlider).toHaveValue("20");
+  //   // Manually set the volume using the slider
+  //   fireEvent.change(volumeSlider, { target: { value: 20 } });
+  //   expect(volumeSlider).toHaveValue("20");
 
-    // Mute the player
-    const muteButton = screen.getByLabelText("Mute video");
-    await userEvent.click(muteButton);
+  //   // Mute the player
+  //   const muteButton = screen.getByLabelText("Mute video");
+  //   await userEvent.click(muteButton);
 
-    expect(volumeSlider).toHaveValue("0");
+  //   expect(volumeSlider).toHaveValue("0");
 
-    //  Unmute player
-    await userEvent.click(muteButton);
+  //   //  Unmute player
+  //   await userEvent.click(muteButton);
 
-    expect(volumeSlider).toHaveValue("20");
-  });
+  //   expect(volumeSlider).toHaveValue("20");
+  // });
 });

--- a/features/players/components/__tests__/VideoPlayer.test.tsx
+++ b/features/players/components/__tests__/VideoPlayer.test.tsx
@@ -43,11 +43,6 @@ const playerWrapperPaused: PlayerClass = {
   isPaused: () => true,
 };
 
-const playerWrapperUnmuted: PlayerClass = {
-  ...playerWrapperPlaying,
-  getMuted: () => false,
-};
-
 const player = new Player(playerWrapperPlaying);
 
 // The max test timeout should be increase to deal with waiting for timeout intervals in certain tests
@@ -401,19 +396,6 @@ describe("Video player control indicators", () => {
 });
 
 describe("Volume and muting control", () => {
-  it("Volume slider returns to player volume level when the player is unmuted", async () => {
-    render(<VideoPlayer player={player} />);
-
-    const volumeSlider = screen.getByLabelText("Volume");
-    expect(volumeSlider).toHaveValue("0");
-
-    // Unmute the video
-    const unmuteButton = screen.getByLabelText("Unmute video");
-    await userEvent.click(unmuteButton);
-
-    expect(volumeSlider).toHaveValue("50");
-  });
-
   it("Player is unmuted automatically when the volume slider is set to a non-zero value", async () => {
     render(<VideoPlayer player={player} />);
 

--- a/features/players/components/__tests__/VideoPlayer.test.tsx
+++ b/features/players/components/__tests__/VideoPlayer.test.tsx
@@ -401,12 +401,6 @@ describe("Video player control indicators", () => {
 });
 
 describe("Volume and muting control", () => {
-  it("Volume slider is set to zero when the player is muted", () => {
-    render(<VideoPlayer player={player} />);
-    const volumeSlider = screen.getByLabelText("Volume");
-    expect(volumeSlider).toHaveValue("0");
-  });
-
   it("Volume slider returns to player volume level when the player is unmuted", async () => {
     render(<VideoPlayer player={player} />);
 
@@ -439,28 +433,4 @@ describe("Volume and muting control", () => {
     const muteButton = screen.getByLabelText("Mute video");
     expect(muteButton).toBeInTheDocument();
   });
-
-  // it("Volume slider retains previous volume when unmuted", async () => {
-  //   // const player = new Player(playerWrapperUnmuted);
-  //   render(<VideoPlayer player={player} />);
-
-  //   // Volume slider should be initialising at 50 volume
-  //   const volumeSlider = screen.getByLabelText("Volume");
-  //   expect(volumeSlider).toHaveValue("50");
-
-  //   // Manually set the volume using the slider
-  //   fireEvent.change(volumeSlider, { target: { value: 20 } });
-  //   expect(volumeSlider).toHaveValue("20");
-
-  //   // Mute the player
-  //   const muteButton = screen.getByLabelText("Mute video");
-  //   await userEvent.click(muteButton);
-
-  //   expect(volumeSlider).toHaveValue("0");
-
-  //   //  Unmute player
-  //   await userEvent.click(muteButton);
-
-  //   expect(volumeSlider).toHaveValue("20");
-  // });
 });

--- a/features/players/components/__tests__/VolumeSlider.test.tsx
+++ b/features/players/components/__tests__/VolumeSlider.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { VolumeSlider } from "features/players/components/video-controls/VolumeSlider";
 
 const playerMock = {
@@ -28,5 +29,20 @@ describe("Volume slider", () => {
     );
     const slider = screen.getByTestId("slider");
     expect(slider).toHaveClass("hide");
+  });
+
+  it("Keyboard interaction changes volume in 5 unit steps", async () => {
+    render(
+      <VolumeSlider
+        // @ts-expect-error we do not require a full player mock for testing purposes
+        player={playerMock}
+      />
+    );
+    const slider = screen.getByLabelText("Volume");
+
+    // Focus the slider
+    await userEvent.click(slider);
+    await userEvent.keyboard("[ArrowRight]");
+    expect(slider).toHaveValue("55");
   });
 });

--- a/features/players/components/__tests__/VolumeSlider.test.tsx
+++ b/features/players/components/__tests__/VolumeSlider.test.tsx
@@ -13,19 +13,19 @@ const playerMock: Player = {
 describe("Volume slider", () => {
   it("Volume slider reflects current player volume", () => {
     playerMock.getMuted = () => false;
-    render(<VolumeSlider player={playerMock} />);
+    render(<VolumeSlider player={playerMock} setPlayerMuted={jest.fn} />);
     const slider = screen.getByLabelText("Volume");
     expect(slider).toHaveValue("50");
   });
 
   it("Volume slider hides when specified", () => {
-    render(<VolumeSlider player={playerMock} showVolumeSlider={false} />);
+    render(<VolumeSlider player={playerMock} setPlayerMuted={jest.fn} />);
     const slider = screen.getByTestId("slider");
     expect(slider).toHaveClass("hide");
   });
 
   it("Keyboard interaction changes volume in 5 unit steps", async () => {
-    render(<VolumeSlider player={playerMock} />);
+    render(<VolumeSlider player={playerMock} setPlayerMuted={jest.fn} />);
     const slider = screen.getByLabelText("Volume");
 
     // Focus the slider
@@ -37,7 +37,7 @@ describe("Volume slider", () => {
 
   it("Volume slider sets to zero when player is muted", () => {
     playerMock.getMuted = () => true;
-    render(<VolumeSlider player={playerMock} showVolumeSlider={false} />);
+    render(<VolumeSlider player={playerMock} setPlayerMuted={jest.fn} />);
     const slider = screen.getByTestId("slider");
     expect(slider).toHaveClass("hide");
   });

--- a/features/players/components/__tests__/VolumeSlider.test.tsx
+++ b/features/players/components/__tests__/VolumeSlider.test.tsx
@@ -1,48 +1,44 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { Player } from "features/players/api/player";
 import { VolumeSlider } from "features/players/components/video-controls/VolumeSlider";
 
-const playerMock = {
+// @ts-expect-error we do not require a full player mock for testing purposes
+const playerMock: Player = {
   getVolume: () => 50,
   setVolume: jest.fn,
+  getMuted: () => true,
 };
 
 describe("Volume slider", () => {
   it("Volume slider reflects current player volume", () => {
-    render(
-      <VolumeSlider
-        // @ts-expect-error we do not require a full player mock for testing purposes
-        player={playerMock}
-      />
-    );
+    playerMock.getMuted = () => false;
+    render(<VolumeSlider player={playerMock} />);
     const slider = screen.getByLabelText("Volume");
     expect(slider).toHaveValue("50");
   });
 
   it("Volume slider hides when specified", () => {
-    render(
-      <VolumeSlider
-        // @ts-expect-error we do not require a full player mock for testing purposes
-        player={playerMock}
-        showVolumeSlider={false}
-      />
-    );
+    render(<VolumeSlider player={playerMock} showVolumeSlider={false} />);
     const slider = screen.getByTestId("slider");
     expect(slider).toHaveClass("hide");
   });
 
   it("Keyboard interaction changes volume in 5 unit steps", async () => {
-    render(
-      <VolumeSlider
-        // @ts-expect-error we do not require a full player mock for testing purposes
-        player={playerMock}
-      />
-    );
+    render(<VolumeSlider player={playerMock} />);
     const slider = screen.getByLabelText("Volume");
 
     // Focus the slider
     await userEvent.click(slider);
+
     await userEvent.keyboard("[ArrowRight]");
     expect(slider).toHaveValue("55");
+  });
+
+  it("Volume slider sets to zero when player is muted", () => {
+    playerMock.getMuted = () => true;
+    render(<VolumeSlider player={playerMock} showVolumeSlider={false} />);
+    const slider = screen.getByTestId("slider");
+    expect(slider).toHaveClass("hide");
   });
 });

--- a/features/players/components/__tests__/VolumeSlider.test.tsx
+++ b/features/players/components/__tests__/VolumeSlider.test.tsx
@@ -38,7 +38,7 @@ describe("Volume slider", () => {
   it("Volume slider sets to zero when player is muted", () => {
     playerMock.getMuted = () => true;
     render(<VolumeSlider player={playerMock} setPlayerMuted={jest.fn} />);
-    const slider = screen.getByTestId("slider");
-    expect(slider).toHaveClass("hide");
+    const slider = screen.getByLabelText("Volume");
+    expect(slider).toHaveValue("0");
   });
 });

--- a/features/players/components/styles/YouTubeVideoControls.module.css
+++ b/features/players/components/styles/YouTubeVideoControls.module.css
@@ -33,7 +33,7 @@
 }
 
 .durationLarge {
-  width: 54px;
+  width: 56px;
 }
 
 .icons24 {

--- a/features/players/components/video-controls/VideoControls.tsx
+++ b/features/players/components/video-controls/VideoControls.tsx
@@ -29,6 +29,7 @@ interface VideoControlsProps {
   toggleMute: () => void;
   seek: (timeToSkipInSeconds: number) => void;
   playerMuted: boolean;
+  setPlayerMuted: React.Dispatch<React.SetStateAction<boolean>>;
   projectedTime: number | null;
   setLockUserActive: Dispatch<SetStateAction<boolean>>;
 }
@@ -42,6 +43,7 @@ export const VideoControls = ({
   toggleMute,
   seek,
   playerMuted,
+  setPlayerMuted,
   projectedTime,
   setLockUserActive,
 }: VideoControlsProps) => {
@@ -121,7 +123,11 @@ export const VideoControls = ({
           )}
         </ControlButton>
 
-        <VolumeSlider showVolumeSlider={showVolumeSlider} player={player} />
+        <VolumeSlider
+          showVolumeSlider={showVolumeSlider}
+          player={player}
+          setPlayerMuted={setPlayerMuted}
+        />
 
         <ControlButton
           tooltipText="Back 10 min"

--- a/features/players/components/video-controls/VolumeSlider.tsx
+++ b/features/players/components/video-controls/VolumeSlider.tsx
@@ -57,6 +57,10 @@ export const VolumeSlider = ({
             player.setMuted(false);
             setPlayerMuted(false);
           }
+          if (event.target.valueAsNumber === 0) {
+            player.setMuted(true);
+            setPlayerMuted(true);
+          }
           setVolume(event.target.valueAsNumber);
           player.setVolume(event.target.valueAsNumber);
         }}
@@ -75,6 +79,11 @@ export const VolumeSlider = ({
           if (playerMuted && volume > 0) {
             player.setMuted(false);
             setPlayerMuted(false);
+          }
+
+          if (volume === 0) {
+            player.setMuted(true);
+            setPlayerMuted(true);
           }
         }}
       />

--- a/features/players/components/video-controls/VolumeSlider.tsx
+++ b/features/players/components/video-controls/VolumeSlider.tsx
@@ -5,11 +5,13 @@ import { useEffect, useState } from "react";
 interface VolumeSliderProps extends React.HTMLAttributes<HTMLDivElement> {
   player: Player;
   showVolumeSlider?: boolean;
+  setPlayerMuted: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export const VolumeSlider = ({
   player,
   showVolumeSlider,
+  setPlayerMuted,
   ...props
 }: VolumeSliderProps) => {
   const [volume, setVolume] = useState(0);
@@ -51,6 +53,10 @@ export const VolumeSlider = ({
         step={1}
         value={volume}
         onChange={(event) => {
+          if (playerMuted && event.target.valueAsNumber > 0) {
+            player.setMuted(false);
+            setPlayerMuted(false);
+          }
           setVolume(event.target.valueAsNumber);
           player.setVolume(event.target.valueAsNumber);
         }}
@@ -64,6 +70,11 @@ export const VolumeSlider = ({
             player.setVolume(volume - 5);
           } else {
             return;
+          }
+
+          if (playerMuted && volume > 0) {
+            player.setMuted(false);
+            setPlayerMuted(false);
           }
         }}
       />

--- a/features/players/components/video-controls/VolumeSlider.tsx
+++ b/features/players/components/video-controls/VolumeSlider.tsx
@@ -15,11 +15,16 @@ export const VolumeSlider = ({
   const [volume, setVolume] = useState(0);
   const [show, setShow] = useState(true);
   const currentPlayerVolume = player.getVolume();
+  const playerMuted = player.getMuted();
 
   // Synchronise the local volume state with player volume
   useEffect(() => {
-    setVolume(currentPlayerVolume);
-  }, [currentPlayerVolume]);
+    if (playerMuted) {
+      setVolume(0);
+    } else {
+      setVolume(currentPlayerVolume);
+    }
+  }, [playerMuted, currentPlayerVolume]);
 
   useEffect(() => {
     if (showVolumeSlider) {

--- a/features/players/components/youtube-player/YouTubeNativePlayer.tsx
+++ b/features/players/components/youtube-player/YouTubeNativePlayer.tsx
@@ -185,6 +185,7 @@ export const YouTubeNativePlayer = ({ videoId }: YouTubeNativePlayerProps) => {
           >
             <VideoControls
               player={player}
+              setPlayerMuted={setPlayerMuted}
               playerPaused={playerPaused}
               toggleFullscreen={() => toggleFullscreen(wrapperRef.current)}
               toggleTheaterMode={toggleTheaterMode}


### PR DESCRIPTION
This PR adds common UX functionality involved with muting the player and how this interacts with the volume slider UI. It meets the following criteria:

- The volume slider is set to zero (even if stylistically only) when the player is muted.
- When the player is unmuted, the volume slider returns to pre-muted levels (if not zero).
- If the player is muted, and the user adjusts volume using the slider (to a non-zero value), the player is unmuted. 
- If the player slides the volume slider to zero, the player is muted. 
- There is unit test coverage.