### PR TITLE
Keyboard control issues

### DIFF
--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -124,7 +124,9 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
 
       // Ensure these key actions do not mess with normal button expectations and functionality
       if (nodeName === "BUTTON" || nodeName === "INPUT") {
-        if (className.includes("controlsBtn")) {
+        if (className.includes("button")) {
+          console.log("Button reached");
+
           signalUserActivity();
         }
         return;

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -119,30 +119,25 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
         return;
       }
 
-      const { nodeName, className } = event.target;
-      const withinPlayer = event.target.closest("#wrapper");
+      const { target, key } = event;
+      const withinPlayer = target.closest("#wrapper");
 
       // Ensure these key actions do not mess with normal button expectations and functionality
-      if (nodeName === "BUTTON" || nodeName === "INPUT") {
-        if (className.includes("button")) {
-          console.log("Button reached");
-
-          signalUserActivity();
-        }
+      if (target.nodeName === "BUTTON" || target.nodeName === "INPUT") {
         return;
       }
 
       // Avoid scrolling the page. Always prioritise play/pause functionality.
-      if (event.key === " ") {
+      if (key === " ") {
         event.preventDefault();
       }
 
-      if (activeDOMKeys.includes(event.key) && !withinPlayer) {
+      if (activeDOMKeys.includes(key) && !withinPlayer) {
         return;
       }
 
       if (
-        activeUserKeys.includes(event.key) &&
+        activeUserKeys.includes(key) &&
         wrapperRef.current === document.activeElement
       ) {
         event.preventDefault();
@@ -153,7 +148,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
         return;
       }
 
-      switch (event.key) {
+      switch (key) {
         case "k":
         case " ":
           playOrPauseVideo();
@@ -279,6 +274,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
             seek={scheduleSeek}
             projectedTime={projectedTime}
             setLockUserActive={setLockUserActive}
+            signalUserActivity={signalUserActivity}
           />
         </div>
       )}

--- a/features/players/components/__tests__/VideoControls.test.tsx
+++ b/features/players/components/__tests__/VideoControls.test.tsx
@@ -60,6 +60,7 @@ const setup = () => {
       toggleMute={toggleMuteMock}
       projectedTime={projectedTime}
       setLockUserActive={jest.fn}
+      signalUserActivity={jest.fn}
     />
   );
 };

--- a/features/players/components/__tests__/VideoPlayer.test.tsx
+++ b/features/players/components/__tests__/VideoPlayer.test.tsx
@@ -307,6 +307,19 @@ describe("Video player controls/user activity timers", () => {
     const customControls = screen.getByTestId("customControls");
     expect(customControls).toHaveClass("controlsHide");
   });
+
+  it("Resets fade out time when user tabs to a control via keyboard", async () => {
+    render(<VideoPlayer player={player} />);
+    const wrapper = screen.getByTestId("wrapper");
+
+    // Focus the wrapper to ensure the keypress is captured correctly
+    wrapper.focus();
+    await userEvent.keyboard("[Tab]");
+    // await userEvent.keyboard("[Tab]");
+
+    const customControls = screen.getByTestId("customControls");
+    expect(customControls).not.toHaveClass("controlsHide");
+  });
 });
 
 describe("Video player control indicators", () => {

--- a/features/players/components/__tests__/VolumeSlider.test.tsx
+++ b/features/players/components/__tests__/VolumeSlider.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Player } from "features/players/api/player";
 import { VolumeSlider } from "features/players/components/video-controls/VolumeSlider";
@@ -10,22 +10,42 @@ const playerMock: Player = {
   getMuted: () => true,
 };
 
+const signalUserActivityMock = () => console.log("Called");
+
 describe("Volume slider", () => {
   it("Volume slider reflects current player volume", () => {
     playerMock.getMuted = () => false;
-    render(<VolumeSlider player={playerMock} setPlayerMuted={jest.fn} />);
+    render(
+      <VolumeSlider
+        player={playerMock}
+        setPlayerMuted={jest.fn}
+        signalUserActivity={jest.fn}
+      />
+    );
     const slider = screen.getByLabelText("Volume");
     expect(slider).toHaveValue("50");
   });
 
   it("Volume slider hides when specified", () => {
-    render(<VolumeSlider player={playerMock} setPlayerMuted={jest.fn} />);
+    render(
+      <VolumeSlider
+        player={playerMock}
+        setPlayerMuted={jest.fn}
+        signalUserActivity={jest.fn}
+      />
+    );
     const slider = screen.getByTestId("slider");
     expect(slider).toHaveClass("hide");
   });
 
   it("Keyboard interaction changes volume in 5 unit steps", async () => {
-    render(<VolumeSlider player={playerMock} setPlayerMuted={jest.fn} />);
+    render(
+      <VolumeSlider
+        player={playerMock}
+        setPlayerMuted={jest.fn}
+        signalUserActivity={jest.fn}
+      />
+    );
     const slider = screen.getByLabelText("Volume");
 
     // Focus the slider
@@ -37,7 +57,13 @@ describe("Volume slider", () => {
 
   it("Volume slider sets to zero when player is muted", () => {
     playerMock.getMuted = () => true;
-    render(<VolumeSlider player={playerMock} setPlayerMuted={jest.fn} />);
+    render(
+      <VolumeSlider
+        player={playerMock}
+        setPlayerMuted={jest.fn}
+        signalUserActivity={jest.fn}
+      />
+    );
     const slider = screen.getByLabelText("Volume");
     expect(slider).toHaveValue("0");
   });

--- a/features/players/components/video-controls/VideoControls.tsx
+++ b/features/players/components/video-controls/VideoControls.tsx
@@ -138,9 +138,10 @@ export const VideoControls = ({
         </ControlButton>
 
         <VolumeSlider
-          showVolumeSlider={showVolumeSlider}
           player={player}
+          showVolumeSlider={showVolumeSlider}
           setPlayerMuted={setPlayerMuted}
+          signalUserActivity={signalUserActivity}
         />
 
         <ControlButton

--- a/features/players/components/video-controls/VideoControls.tsx
+++ b/features/players/components/video-controls/VideoControls.tsx
@@ -67,10 +67,11 @@ export const VideoControls = ({
   useEffect(() => {
     if (showSettings) {
       setLockUserActive(true);
+      signalUserActivity();
     } else {
       setLockUserActive(false);
     }
-  }, [showSettings, setLockUserActive]);
+  }, [showSettings, setLockUserActive, signalUserActivity]);
 
   const handleControlButtonFocus = (event: React.FocusEvent<HTMLElement>) => {
     if (
@@ -237,7 +238,9 @@ export const VideoControls = ({
             aria-haspopup="menu"
             aria-expanded={showSettings}
             aria-label="Open video settings menu"
-            onClick={() => setShowSettings((prevState) => !prevState)}
+            onClick={() => {
+              setShowSettings((prevState) => !prevState);
+            }}
           >
             <SettingsGearIcon className={styles.icons24} fill="#FFFFFF" />
           </ControlButton>

--- a/features/players/components/video-controls/VideoControls.tsx
+++ b/features/players/components/video-controls/VideoControls.tsx
@@ -1,5 +1,7 @@
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import styles from "features/players/components/styles/YouTubeVideoControls.module.css";
+import buttonStyles from "features/players/components/styles/ControlButton.module.css";
+import volumeStyles from "features/players/components/styles/VolumeSlider.module.css";
 import MutedIcon from "icons/MutedIcon";
 import VolumeIcon from "icons/VolumeIcon";
 import BackTenIcon from "icons/BackTenIcon";
@@ -32,6 +34,7 @@ interface VideoControlsProps {
   setPlayerMuted: React.Dispatch<React.SetStateAction<boolean>>;
   projectedTime: number | null;
   setLockUserActive: Dispatch<SetStateAction<boolean>>;
+  signalUserActivity: () => void;
 }
 
 export const VideoControls = ({
@@ -46,6 +49,7 @@ export const VideoControls = ({
   setPlayerMuted,
   projectedTime,
   setLockUserActive,
+  signalUserActivity,
 }: VideoControlsProps) => {
   // Controls display of video quality settings menu
   const [showSettings, setShowSettings] = useState(false);
@@ -68,10 +72,20 @@ export const VideoControls = ({
     }
   }, [showSettings, setLockUserActive]);
 
+  const handleControlButtonFocus = (event: React.FocusEvent<HTMLElement>) => {
+    if (
+      event.target.classList.contains(buttonStyles.button) ||
+      event.target.classList.contains(volumeStyles.slider)
+    ) {
+      signalUserActivity();
+    }
+  };
+
   return (
     <div
       className={styles.controlsContainer}
       onMouseLeave={() => setShowVolumeSlider(false)}
+      onFocus={handleControlButtonFocus}
     >
       <div
         className={styles.leftControls}

--- a/features/players/components/video-controls/VolumeSlider.tsx
+++ b/features/players/components/video-controls/VolumeSlider.tsx
@@ -6,12 +6,14 @@ interface VolumeSliderProps extends React.HTMLAttributes<HTMLDivElement> {
   player: Player;
   showVolumeSlider?: boolean;
   setPlayerMuted: React.Dispatch<React.SetStateAction<boolean>>;
+  signalUserActivity: () => void;
 }
 
 export const VolumeSlider = ({
   player,
   showVolumeSlider,
   setPlayerMuted,
+  signalUserActivity,
   ...props
 }: VolumeSliderProps) => {
   const [volume, setVolume] = useState(0);
@@ -63,6 +65,7 @@ export const VolumeSlider = ({
           }
           setVolume(event.target.valueAsNumber);
           player.setVolume(event.target.valueAsNumber);
+          signalUserActivity();
         }}
         className={styles.slider}
         onKeyDown={(event) => {

--- a/features/players/components/youtube-player/YouTubeNativePlayer.tsx
+++ b/features/players/components/youtube-player/YouTubeNativePlayer.tsx
@@ -195,6 +195,7 @@ export const YouTubeNativePlayer = ({ videoId }: YouTubeNativePlayerProps) => {
               seek={scheduleSeek}
               projectedTime={projectedTime}
               setLockUserActive={setLockUserActive}
+              signalUserActivity={signalUserActivity}
             />
           </div>
         )}


### PR DESCRIPTION
This PR addresses the issues with controls fading when focusing with the keyboard or opening settings with the keyboard. It meets the following criteria:

- The control bar displays when tabbing to any control
- The control bar displays when pressing enter or space (i.e. activating a control).
- The control bar fade-out time is revisited to potentially increase the time. 
- There is unit test coverage if possible.