### PR TITLE
Volume slider focus bug

### DIFF
--- a/features/players/components/video-controls/VideoControls.tsx
+++ b/features/players/components/video-controls/VideoControls.tsx
@@ -120,7 +120,9 @@ export const VideoControls = ({
             toggleMute();
             releaseFocus();
           }}
-          onMouseOver={() => setShowVolumeSlider(true)}
+          onMouseOver={() => {
+            setShowVolumeSlider(true);
+          }}
           aria-label={playerMuted ? "Unmute video" : "Mute video"}
         >
           {playerMuted ? (

--- a/features/players/components/video-controls/VolumeSlider.tsx
+++ b/features/players/components/video-controls/VolumeSlider.tsx
@@ -1,4 +1,5 @@
 import styles from "features/players/components/styles/VolumeSlider.module.css";
+import buttonStyles from "features/players/components/styles/ControlButton.module.css";
 import { Player } from "features/players/api/player";
 import { useEffect, useState } from "react";
 
@@ -44,7 +45,13 @@ export const VolumeSlider = ({
       onMouseLeave={props.onMouseLeave}
       data-testid="slider"
       onFocus={() => setShow(true)}
-      onBlur={() => setShow(false)}
+      onBlur={(event) => {
+        if (event.relatedTarget?.classList.contains(buttonStyles.button)) {
+          if (!showVolumeSlider) {
+            setShow(false);
+          }
+        }
+      }}
     >
       <div className={styles.progress} style={{ width: `${volume}%` }}></div>
       <input


### PR DESCRIPTION
This PR fixes the bugs related to focusing on and off the volume slider. It meets the following criteria:

- Ensure the volume slider remains open when the volume/mute button is pressed.
- Remove focus from the slider when it is hidden, as the UI result is not intended