### PR TITLE
Smooth volume changes

### DIFF
--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -43,8 +43,6 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
 
   // Set the player volume according to local changes in volume. By working with the local volume state, we get a fluid UI as opposed to a laggy API interaction. It is fine to have a trace delay between local change and API player volume update.
   React.useEffect(() => {
-    console.log(localVolume);
-
     if (player) {
       player.setVolume(localVolume);
     }

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -287,6 +287,8 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
             projectedTime={projectedTime}
             setLockUserActive={setLockUserActive}
             signalUserActivity={signalUserActivity}
+            localVolume={localVolume}
+            setLocalVolume={setLocalVolume}
           />
         </div>
       )}

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -185,7 +185,6 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
           toggleTheaterMode();
           break;
         case "ArrowDown":
-          // player.setVolume(player.getVolume() - 5);
           setLocalVolume((prevVol) => Math.max(prevVol - 5, 0));
           if (player.getVolume() === 0) {
             setPlayerMuted(true);
@@ -199,7 +198,6 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
         case "ArrowUp":
           player.setMuted(false);
           setPlayerMuted(false);
-          // player.setVolume(player.getVolume() + 5);
           setLocalVolume((prevVol) => Math.min(prevVol + 5, 100));
           triggerControlIndication("volumeUp");
           triggerVolumeLevelIndication();
@@ -256,7 +254,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
       ></div>
       <div className={styles.indicatorContainer}>
         {showVolumeLevelIndicator && player && (
-          <VolumeLevelIndicator currentVolume={player.getVolume()} />
+          <VolumeLevelIndicator currentVolume={localVolume} />
         )}
 
         {seekAmount && <SeekIndicator projectedSeekInSeconds={seekAmount} />}

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -34,10 +34,21 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
   } = useControlIndicators();
   const wrapperRef = React.useRef<HTMLDivElement | null>(null);
 
+  const [localVolume, setLocalVolume] = React.useState(100);
+
   // Use local state to avoid the long delays of an API call to check muted state when toggling icons and UI
   const [playerMuted, setPlayerMuted] = React.useState(true);
   const [playerPaused, setPlayerPaused] = React.useState(false);
   const [theaterMode, setTheaterMode] = React.useState(false);
+
+  // Set the player volume according to local changes in volume. By working with the local volume state, we get a fluid UI as opposed to a laggy API interaction. It is fine to have a trace delay between local change and API player volume update.
+  React.useEffect(() => {
+    console.log(localVolume);
+
+    if (player) {
+      player.setVolume(localVolume);
+    }
+  }, [localVolume, player]);
 
   // Ensure the local playerState state is set on play/pause events. This ensures other elements modify with each of the changes as needed
   React.useEffect(() => {
@@ -60,6 +71,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
     if (!player) {
       return;
     }
+    // Do not adjust local volume to zero here. Local volume maintains the 'memory' of volume when the player is unmuted
     if (player.getMuted()) {
       setPlayerMuted(false);
       player.setMuted(false);
@@ -173,7 +185,8 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
           toggleTheaterMode();
           break;
         case "ArrowDown":
-          player.setVolume(player.getVolume() - 5);
+          // player.setVolume(player.getVolume() - 5);
+          setLocalVolume((prevVol) => prevVol - 5);
           if (player.getVolume() === 0) {
             setPlayerMuted(true);
             player.setMuted(true);
@@ -186,7 +199,8 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
         case "ArrowUp":
           player.setMuted(false);
           setPlayerMuted(false);
-          player.setVolume(player.getVolume() + 5);
+          // player.setVolume(player.getVolume() + 5);
+          setLocalVolume((prevVol) => prevVol + 5);
           triggerControlIndication("volumeUp");
           triggerVolumeLevelIndication();
           break;

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -186,7 +186,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
           break;
         case "ArrowDown":
           // player.setVolume(player.getVolume() - 5);
-          setLocalVolume((prevVol) => prevVol - 5);
+          setLocalVolume((prevVol) => Math.max(prevVol - 5, 0));
           if (player.getVolume() === 0) {
             setPlayerMuted(true);
             player.setMuted(true);
@@ -200,7 +200,7 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
           player.setMuted(false);
           setPlayerMuted(false);
           // player.setVolume(player.getVolume() + 5);
-          setLocalVolume((prevVol) => prevVol + 5);
+          setLocalVolume((prevVol) => Math.min(prevVol + 5, 100));
           triggerControlIndication("volumeUp");
           triggerVolumeLevelIndication();
           break;

--- a/features/players/components/__tests__/VideoPlayer.test.tsx
+++ b/features/players/components/__tests__/VideoPlayer.test.tsx
@@ -428,4 +428,15 @@ describe("Volume and muting control", () => {
     const muteButton = screen.getByLabelText("Mute video");
     expect(muteButton).toBeInTheDocument();
   });
+
+  it("Keyboard interaction with volume slider changes volume in 5 unit steps", async () => {
+    render(<VideoPlayer player={player} />);
+    const slider = screen.getByLabelText("Volume");
+
+    // Focus the slider
+    await userEvent.click(slider);
+
+    await userEvent.keyboard("[ArrowRight]");
+    expect(slider).toHaveValue("55");
+  });
 });

--- a/features/players/components/__tests__/VideoPlayer.test.tsx
+++ b/features/players/components/__tests__/VideoPlayer.test.tsx
@@ -11,6 +11,10 @@ const seekMock = jest.fn();
 const setVolumeMock = jest.fn();
 const setMutedMock = jest.fn();
 
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
 const playerWrapperPlaying: PlayerClass = {
   getCurrentTime: () => 100,
   getMuted: () => true,
@@ -370,9 +374,9 @@ describe("Video player control indicators", () => {
 
     // First focus the wrapper to ensure the keypress is captured correctly
     wrapper.focus();
-    await userEvent.keyboard("[ArrowUp]");
+    await userEvent.keyboard("[ArrowDown]");
 
-    const indicator = screen.getByText("50%");
+    const indicator = screen.getByText("95%");
 
     expect(indicator).toBeInTheDocument();
   });
@@ -383,9 +387,9 @@ describe("Video player control indicators", () => {
 
     // First focus the wrapper to ensure the keypress is captured correctly
     wrapper.focus();
-    await userEvent.keyboard("[ArrowUp]");
+    await userEvent.keyboard("[ArrowDown]");
 
-    const indicator = screen.queryByText("50%");
+    const indicator = screen.queryByText("95%");
     expect(indicator).toBeInTheDocument();
 
     await act(async () => {
@@ -436,7 +440,7 @@ describe("Volume and muting control", () => {
     // Focus the slider
     await userEvent.click(slider);
 
-    await userEvent.keyboard("[ArrowRight]");
-    expect(slider).toHaveValue("55");
+    await userEvent.keyboard("[ArrowLeft]");
+    expect(slider).toHaveValue("95");
   });
 });

--- a/features/players/components/__tests__/VolumeSlider.test.tsx
+++ b/features/players/components/__tests__/VolumeSlider.test.tsx
@@ -10,8 +10,6 @@ const playerMock: Player = {
   getMuted: () => true,
 };
 
-const signalUserActivityMock = () => console.log("Called");
-
 describe("Volume slider", () => {
   it("Volume slider reflects current player volume", () => {
     playerMock.getMuted = () => false;
@@ -20,6 +18,7 @@ describe("Volume slider", () => {
         player={playerMock}
         setPlayerMuted={jest.fn}
         signalUserActivity={jest.fn}
+        playerMuted={true}
       />
     );
     const slider = screen.getByLabelText("Volume");
@@ -32,6 +31,7 @@ describe("Volume slider", () => {
         player={playerMock}
         setPlayerMuted={jest.fn}
         signalUserActivity={jest.fn}
+        playerMuted={true}
       />
     );
     const slider = screen.getByTestId("slider");
@@ -44,6 +44,7 @@ describe("Volume slider", () => {
         player={playerMock}
         setPlayerMuted={jest.fn}
         signalUserActivity={jest.fn}
+        playerMuted={true}
       />
     );
     const slider = screen.getByLabelText("Volume");
@@ -62,6 +63,7 @@ describe("Volume slider", () => {
         player={playerMock}
         setPlayerMuted={jest.fn}
         signalUserActivity={jest.fn}
+        playerMuted={true}
       />
     );
     const slider = screen.getByLabelText("Volume");

--- a/features/players/components/__tests__/VolumeSlider.test.tsx
+++ b/features/players/components/__tests__/VolumeSlider.test.tsx
@@ -1,24 +1,21 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Player } from "features/players/api/player";
 import { VolumeSlider } from "features/players/components/video-controls/VolumeSlider";
 
 // @ts-expect-error we do not require a full player mock for testing purposes
 const playerMock: Player = {
-  getVolume: () => 50,
-  setVolume: jest.fn,
-  getMuted: () => true,
+  setMuted: jest.fn,
 };
 
 describe("Volume slider", () => {
   it("Volume slider reflects current player volume", () => {
-    playerMock.getMuted = () => false;
     render(
       <VolumeSlider
         player={playerMock}
         setPlayerMuted={jest.fn}
         signalUserActivity={jest.fn}
-        playerMuted={true}
+        playerMuted={false}
         localVolume={50}
         setLocalVolume={jest.fn}
       />
@@ -33,7 +30,7 @@ describe("Volume slider", () => {
         player={playerMock}
         setPlayerMuted={jest.fn}
         signalUserActivity={jest.fn}
-        playerMuted={true}
+        playerMuted={false}
         localVolume={50}
         setLocalVolume={jest.fn}
       />
@@ -42,28 +39,7 @@ describe("Volume slider", () => {
     expect(slider).toHaveClass("hide");
   });
 
-  it("Keyboard interaction changes volume in 5 unit steps", async () => {
-    render(
-      <VolumeSlider
-        player={playerMock}
-        setPlayerMuted={jest.fn}
-        signalUserActivity={jest.fn}
-        playerMuted={true}
-        localVolume={50}
-        setLocalVolume={jest.fn}
-      />
-    );
-    const slider = screen.getByLabelText("Volume");
-
-    // Focus the slider
-    await userEvent.click(slider);
-
-    await userEvent.keyboard("[ArrowRight]");
-    expect(slider).toHaveValue("55");
-  });
-
   it("Volume slider sets to zero when player is muted", () => {
-    playerMock.getMuted = () => true;
     render(
       <VolumeSlider
         player={playerMock}

--- a/features/players/components/__tests__/VolumeSlider.test.tsx
+++ b/features/players/components/__tests__/VolumeSlider.test.tsx
@@ -19,6 +19,8 @@ describe("Volume slider", () => {
         setPlayerMuted={jest.fn}
         signalUserActivity={jest.fn}
         playerMuted={true}
+        localVolume={50}
+        setLocalVolume={jest.fn}
       />
     );
     const slider = screen.getByLabelText("Volume");
@@ -32,6 +34,8 @@ describe("Volume slider", () => {
         setPlayerMuted={jest.fn}
         signalUserActivity={jest.fn}
         playerMuted={true}
+        localVolume={50}
+        setLocalVolume={jest.fn}
       />
     );
     const slider = screen.getByTestId("slider");
@@ -45,6 +49,8 @@ describe("Volume slider", () => {
         setPlayerMuted={jest.fn}
         signalUserActivity={jest.fn}
         playerMuted={true}
+        localVolume={50}
+        setLocalVolume={jest.fn}
       />
     );
     const slider = screen.getByLabelText("Volume");
@@ -64,6 +70,8 @@ describe("Volume slider", () => {
         setPlayerMuted={jest.fn}
         signalUserActivity={jest.fn}
         playerMuted={true}
+        localVolume={50}
+        setLocalVolume={jest.fn}
       />
     );
     const slider = screen.getByLabelText("Volume");

--- a/features/players/components/__tests__/VolumeSlider.test.tsx
+++ b/features/players/components/__tests__/VolumeSlider.test.tsx
@@ -23,7 +23,7 @@ describe("Volume slider", () => {
     expect(slider).toHaveValue("50");
   });
 
-  it("Volume slider hides when specified", () => {
+  it("Volume slider hides by default", () => {
     render(
       <VolumeSlider
         player={playerMock}
@@ -36,6 +36,22 @@ describe("Volume slider", () => {
     );
     const slider = screen.getByTestId("slider");
     expect(slider).toHaveClass("hide");
+  });
+
+  it("Volume slider displays when showVoluemSlider prop is true", () => {
+    render(
+      <VolumeSlider
+        player={playerMock}
+        setPlayerMuted={jest.fn}
+        signalUserActivity={jest.fn}
+        playerMuted={false}
+        localVolume={50}
+        setLocalVolume={jest.fn}
+        showVolumeSlider={true}
+      />
+    );
+    const slider = screen.getByTestId("slider");
+    expect(slider).toHaveClass("show");
   });
 
   it("Volume slider sets to zero when player is muted", () => {
@@ -51,5 +67,20 @@ describe("Volume slider", () => {
     );
     const slider = screen.getByLabelText("Volume");
     expect(slider).toHaveValue("0");
+  });
+
+  it("Volume active bar width reflects current volume level", () => {
+    render(
+      <VolumeSlider
+        player={playerMock}
+        setPlayerMuted={jest.fn}
+        signalUserActivity={jest.fn}
+        playerMuted={false}
+        localVolume={50}
+        setLocalVolume={jest.fn}
+      />
+    );
+    const slider = screen.getByTestId("activeBar");
+    expect(slider).toHaveStyle("width: 50%");
   });
 });

--- a/features/players/components/__tests__/VolumeSlider.test.tsx
+++ b/features/players/components/__tests__/VolumeSlider.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { Player } from "features/players/api/player";
 import { VolumeSlider } from "features/players/components/video-controls/VolumeSlider";
 
@@ -82,5 +82,44 @@ describe("Volume slider", () => {
     );
     const slider = screen.getByTestId("activeBar");
     expect(slider).toHaveStyle("width: 50%");
+  });
+
+  it("Local player mute state is adjusted when the user changes volume to zero", () => {
+    const setPlayerMuted = jest.fn();
+
+    render(
+      <VolumeSlider
+        player={playerMock}
+        setPlayerMuted={setPlayerMuted}
+        signalUserActivity={jest.fn}
+        playerMuted={false}
+        localVolume={50}
+        setLocalVolume={jest.fn}
+      />
+    );
+    const slider = screen.getByLabelText("Volume");
+    fireEvent.change(slider, { target: { value: "0" } });
+
+    expect(setPlayerMuted).toHaveBeenCalledWith(true);
+  });
+
+  it("Sets the volume level when the range input is changed", () => {
+    const setLocalVolume = jest.fn();
+
+    render(
+      <VolumeSlider
+        player={playerMock}
+        setPlayerMuted={jest.fn}
+        signalUserActivity={jest.fn}
+        playerMuted={false}
+        localVolume={50}
+        setLocalVolume={setLocalVolume}
+      />
+    );
+
+    const slider = screen.getByLabelText("Volume");
+    fireEvent.change(slider, { target: { value: "25" } });
+
+    expect(setLocalVolume).toHaveBeenCalledWith(25);
   });
 });

--- a/features/players/components/__tests__/VolumeSlider.test.tsx
+++ b/features/players/components/__tests__/VolumeSlider.test.tsx
@@ -84,7 +84,7 @@ describe("Volume slider", () => {
     expect(slider).toHaveStyle("width: 50%");
   });
 
-  it("Local player mute state is adjusted when the user changes volume to zero", () => {
+  it("Sets the local playerMuted state when the range input is set to zero", () => {
     const setPlayerMuted = jest.fn();
 
     render(

--- a/features/players/components/__tests__/VolumeSlider.test.tsx
+++ b/features/players/components/__tests__/VolumeSlider.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { Player } from "features/players/api/player";
 import { VolumeSlider } from "features/players/components/video-controls/VolumeSlider";
 

--- a/features/players/components/video-controls/VideoControls.tsx
+++ b/features/players/components/video-controls/VideoControls.tsx
@@ -145,6 +145,7 @@ export const VideoControls = ({
           showVolumeSlider={showVolumeSlider}
           setPlayerMuted={setPlayerMuted}
           signalUserActivity={signalUserActivity}
+          playerMuted={playerMuted}
         />
 
         <ControlButton

--- a/features/players/components/video-controls/VideoControls.tsx
+++ b/features/players/components/video-controls/VideoControls.tsx
@@ -35,6 +35,8 @@ interface VideoControlsProps {
   projectedTime: number | null;
   setLockUserActive: Dispatch<SetStateAction<boolean>>;
   signalUserActivity: () => void;
+  localVolume: number;
+  setLocalVolume: React.Dispatch<React.SetStateAction<number>>;
 }
 
 export const VideoControls = ({
@@ -50,6 +52,8 @@ export const VideoControls = ({
   projectedTime,
   setLockUserActive,
   signalUserActivity,
+  localVolume,
+  setLocalVolume,
 }: VideoControlsProps) => {
   // Controls display of video quality settings menu
   const [showSettings, setShowSettings] = useState(false);
@@ -146,6 +150,8 @@ export const VideoControls = ({
           setPlayerMuted={setPlayerMuted}
           signalUserActivity={signalUserActivity}
           playerMuted={playerMuted}
+          localVolume={localVolume}
+          setLocalVolume={setLocalVolume}
         />
 
         <ControlButton

--- a/features/players/components/video-controls/VolumeSlider.tsx
+++ b/features/players/components/video-controls/VolumeSlider.tsx
@@ -27,6 +27,14 @@ export const VolumeSlider = ({
   const [show, setShow] = useState(true);
   const sliderRef = React.useRef<HTMLInputElement | null>(null);
 
+  const volumeBarRef = React.useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (volumeBarRef.current) {
+      volumeBarRef.current.style.width = playerMuted ? "0" : `${localVolume}%`;
+    }
+  }, [localVolume, playerMuted]);
+
   useEffect(() => {
     if (!showVolumeSlider && document.activeElement !== sliderRef.current) {
       setShow(false);
@@ -42,7 +50,8 @@ export const VolumeSlider = ({
     >
       <div
         className={styles.progress}
-        style={{ width: `${playerMuted ? 0 : localVolume}%` }}
+        // style={{ width: `${playerMuted ? 0 : localVolume}%` }}
+        ref={volumeBarRef}
       ></div>
       <input
         type="range"
@@ -73,7 +82,6 @@ export const VolumeSlider = ({
             setPlayerMuted(true);
           }
           setLocalVolume(event.target.valueAsNumber);
-          // player.setVolume(event.target.valueAsNumber);
           signalUserActivity();
         }}
         className={styles.slider}

--- a/features/players/components/video-controls/VolumeSlider.tsx
+++ b/features/players/components/video-controls/VolumeSlider.tsx
@@ -37,10 +37,6 @@ export const VolumeSlider = ({
   }, [playerMuted, currentPlayerVolume]);
 
   useEffect(() => {
-    player.setVolume(volume);
-  }, [player, volume]);
-
-  useEffect(() => {
     if (!showVolumeSlider && document.activeElement !== sliderRef.current) {
       setShow(false);
     } else {
@@ -55,7 +51,7 @@ export const VolumeSlider = ({
     >
       <div
         className={styles.progress}
-        style={{ width: `${localVolume}%` }}
+        style={{ width: `${playerMuted ? 0 : localVolume}%` }}
       ></div>
       <input
         type="range"
@@ -64,7 +60,7 @@ export const VolumeSlider = ({
         max={100}
         step={1}
         ref={sliderRef}
-        value={localVolume}
+        value={playerMuted ? 0 : localVolume}
         onBlur={(event) => {
           if (
             event.relatedTarget?.classList.contains(buttonStyles.button) ||
@@ -93,10 +89,8 @@ export const VolumeSlider = ({
         onKeyDown={(event) => {
           if (event.key === "ArrowUp" || event.key === "ArrowRight") {
             setLocalVolume(Math.min(volume + 5, 100));
-            // player.setVolume(volume + 5);
           } else if (event.key === "ArrowDown" || event.key === "ArrowLeft") {
             setLocalVolume(Math.max(volume - 5, 0));
-            // player.setVolume(volume - 5);
           } else {
             return;
           }

--- a/features/players/components/video-controls/VolumeSlider.tsx
+++ b/features/players/components/video-controls/VolumeSlider.tsx
@@ -47,7 +47,11 @@ export const VolumeSlider = ({
       className={`${styles.inputContainer} ${show ? styles.show : styles.hide}`}
       data-testid="slider"
     >
-      <div className={styles.progress} ref={volumeBarRef}></div>
+      <div
+        className={styles.progress}
+        ref={volumeBarRef}
+        data-testid="activeBar"
+      ></div>
       <input
         type="range"
         id="volume"

--- a/features/players/components/video-controls/VolumeSlider.tsx
+++ b/features/players/components/video-controls/VolumeSlider.tsx
@@ -10,6 +10,8 @@ interface VolumeSliderProps extends React.HTMLAttributes<HTMLDivElement> {
   setPlayerMuted: React.Dispatch<React.SetStateAction<boolean>>;
   signalUserActivity: () => void;
   playerMuted: boolean;
+  localVolume: number;
+  setLocalVolume: React.Dispatch<React.SetStateAction<number>>;
 }
 
 export const VolumeSlider = ({
@@ -18,6 +20,8 @@ export const VolumeSlider = ({
   setPlayerMuted,
   signalUserActivity,
   playerMuted,
+  localVolume,
+  setLocalVolume,
   ...props
 }: VolumeSliderProps) => {
   const [volume, setVolume] = useState(0);
@@ -49,7 +53,10 @@ export const VolumeSlider = ({
       className={`${styles.inputContainer} ${show ? styles.show : styles.hide}`}
       data-testid="slider"
     >
-      <div className={styles.progress} style={{ width: `${volume}%` }}></div>
+      <div
+        className={styles.progress}
+        style={{ width: `${localVolume}%` }}
+      ></div>
       <input
         type="range"
         id="volume"
@@ -57,7 +64,7 @@ export const VolumeSlider = ({
         max={100}
         step={1}
         ref={sliderRef}
-        value={volume}
+        value={localVolume}
         onBlur={(event) => {
           if (
             event.relatedTarget?.classList.contains(buttonStyles.button) ||
@@ -78,18 +85,18 @@ export const VolumeSlider = ({
             player.setMuted(true);
             setPlayerMuted(true);
           }
-          setVolume(event.target.valueAsNumber);
+          setLocalVolume(event.target.valueAsNumber);
           // player.setVolume(event.target.valueAsNumber);
           signalUserActivity();
         }}
         className={styles.slider}
         onKeyDown={(event) => {
           if (event.key === "ArrowUp" || event.key === "ArrowRight") {
-            setVolume(Math.min(volume + 5, 100));
-            player.setVolume(volume + 5);
+            setLocalVolume(Math.min(volume + 5, 100));
+            // player.setVolume(volume + 5);
           } else if (event.key === "ArrowDown" || event.key === "ArrowLeft") {
-            setVolume(Math.max(volume - 5, 0));
-            player.setVolume(volume - 5);
+            setLocalVolume(Math.max(volume - 5, 0));
+            // player.setVolume(volume - 5);
           } else {
             return;
           }

--- a/features/players/components/video-controls/VolumeSlider.tsx
+++ b/features/players/components/video-controls/VolumeSlider.tsx
@@ -22,13 +22,12 @@ export const VolumeSlider = ({
   playerMuted,
   localVolume,
   setLocalVolume,
-  ...props
 }: VolumeSliderProps) => {
   const [show, setShow] = useState(true);
   const sliderRef = React.useRef<HTMLInputElement | null>(null);
-
   const volumeBarRef = React.useRef<HTMLDivElement | null>(null);
 
+  // Dynamically set the width of the 'active' portion of the volume slider.
   useEffect(() => {
     if (volumeBarRef.current) {
       volumeBarRef.current.style.width = playerMuted ? "0" : `${localVolume}%`;
@@ -48,11 +47,7 @@ export const VolumeSlider = ({
       className={`${styles.inputContainer} ${show ? styles.show : styles.hide}`}
       data-testid="slider"
     >
-      <div
-        className={styles.progress}
-        // style={{ width: `${playerMuted ? 0 : localVolume}%` }}
-        ref={volumeBarRef}
-      ></div>
+      <div className={styles.progress} ref={volumeBarRef}></div>
       <input
         type="range"
         id="volume"

--- a/features/players/components/video-controls/VolumeSlider.tsx
+++ b/features/players/components/video-controls/VolumeSlider.tsx
@@ -1,7 +1,7 @@
 import styles from "features/players/components/styles/VolumeSlider.module.css";
 import buttonStyles from "features/players/components/styles/ControlButton.module.css";
 import { Player } from "features/players/api/player";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import * as React from "react";
 
 interface VolumeSliderProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -24,17 +24,8 @@ export const VolumeSlider = ({
   setLocalVolume,
   ...props
 }: VolumeSliderProps) => {
-  const [volume, setVolume] = useState(0);
   const [show, setShow] = useState(true);
-  const currentPlayerVolume = player.getVolume();
   const sliderRef = React.useRef<HTMLInputElement | null>(null);
-
-  // Synchronise the local volume state with player volume
-  useEffect(() => {
-    if (playerMuted) {
-      setVolume(0);
-    }
-  }, [playerMuted, currentPlayerVolume]);
 
   useEffect(() => {
     if (!showVolumeSlider && document.activeElement !== sliderRef.current) {
@@ -88,19 +79,19 @@ export const VolumeSlider = ({
         className={styles.slider}
         onKeyDown={(event) => {
           if (event.key === "ArrowUp" || event.key === "ArrowRight") {
-            setLocalVolume(Math.min(volume + 5, 100));
+            setLocalVolume(Math.min(localVolume + 5, 100));
           } else if (event.key === "ArrowDown" || event.key === "ArrowLeft") {
-            setLocalVolume(Math.max(volume - 5, 0));
+            setLocalVolume(Math.max(localVolume - 5, 0));
           } else {
             return;
           }
 
-          if (playerMuted && volume > 0) {
+          if (playerMuted && localVolume > 0) {
             player.setMuted(false);
             setPlayerMuted(false);
           }
 
-          if (volume === 0) {
+          if (localVolume === 0) {
             player.setMuted(true);
             setPlayerMuted(true);
           }

--- a/features/players/components/video-controls/VolumeSlider.tsx
+++ b/features/players/components/video-controls/VolumeSlider.tsx
@@ -9,6 +9,7 @@ interface VolumeSliderProps extends React.HTMLAttributes<HTMLDivElement> {
   showVolumeSlider?: boolean;
   setPlayerMuted: React.Dispatch<React.SetStateAction<boolean>>;
   signalUserActivity: () => void;
+  playerMuted: boolean;
 }
 
 export const VolumeSlider = ({
@@ -16,22 +17,24 @@ export const VolumeSlider = ({
   showVolumeSlider,
   setPlayerMuted,
   signalUserActivity,
+  playerMuted,
   ...props
 }: VolumeSliderProps) => {
   const [volume, setVolume] = useState(0);
   const [show, setShow] = useState(true);
   const currentPlayerVolume = player.getVolume();
-  const playerMuted = player.getMuted();
   const sliderRef = React.useRef<HTMLInputElement | null>(null);
 
   // Synchronise the local volume state with player volume
   useEffect(() => {
     if (playerMuted) {
       setVolume(0);
-    } else {
-      setVolume(currentPlayerVolume);
     }
   }, [playerMuted, currentPlayerVolume]);
+
+  useEffect(() => {
+    player.setVolume(volume);
+  }, [player, volume]);
 
   useEffect(() => {
     if (!showVolumeSlider && document.activeElement !== sliderRef.current) {
@@ -56,8 +59,6 @@ export const VolumeSlider = ({
         ref={sliderRef}
         value={volume}
         onBlur={(event) => {
-          console.log("Bl;urred");
-
           if (
             event.relatedTarget?.classList.contains(buttonStyles.button) ||
             event.relatedTarget?.id === "wrapper"
@@ -78,7 +79,7 @@ export const VolumeSlider = ({
             setPlayerMuted(true);
           }
           setVolume(event.target.valueAsNumber);
-          player.setVolume(event.target.valueAsNumber);
+          // player.setVolume(event.target.valueAsNumber);
           signalUserActivity();
         }}
         className={styles.slider}

--- a/features/players/components/youtube-player/YouTubeNativePlayer.tsx
+++ b/features/players/components/youtube-player/YouTubeNativePlayer.tsx
@@ -21,11 +21,22 @@ export const YouTubeNativePlayer = ({ videoId }: YouTubeNativePlayerProps) => {
   const { scheduleSeek, projectedTime } = useSeek(player);
   const wrapperRef = React.useRef<HTMLDivElement | null>(null);
 
+  const [localVolume, setLocalVolume] = React.useState(100);
+
   // Use local state to avoid the long delays of an API call to check muted state when toggling icons and UI
   const [playerMuted, setPlayerMuted] = React.useState(true);
   const [playerPaused, setPlayerPaused] = React.useState(false);
   const [theaterMode, setTheaterMode] = React.useState(false);
   const [showYTControls, setShowYTControls] = React.useState(true);
+
+  // Set the player volume according to local changes in volume. By working with the local volume state, we get a fluid UI as opposed to a laggy API interaction. It is fine to have a trace delay between local change and API player volume update.
+  React.useEffect(() => {
+    console.log(localVolume);
+
+    if (player) {
+      player.setVolume(localVolume);
+    }
+  }, [localVolume, player]);
 
   // Ensure the local playerState state is set on play/pause events. This ensures other elements modify with each of the changes as needed
   React.useEffect(() => {
@@ -196,6 +207,8 @@ export const YouTubeNativePlayer = ({ videoId }: YouTubeNativePlayerProps) => {
               projectedTime={projectedTime}
               setLockUserActive={setLockUserActive}
               signalUserActivity={signalUserActivity}
+              localVolume={localVolume}
+              setLocalVolume={setLocalVolume}
             />
           </div>
         )}


### PR DESCRIPTION
This PR makes several significant changes to the way volume changes are handled by the video player. This was largely done by making a `localVolume` state that becomes the source of truth for seeing volume. By basing the UI on this local state, all functions are fluid and accurate. It meets the following criteria:

- Every key press causes a clean volume change of 5%, unless at 0% or 100% where the user attempts to go beyond these. 
- Rapid pressing is smoothed out, either with a throttle, or (hopefully) automatically as the first point is addressed. 
- The volume slider does not jump back and forth when sliding.
- The volume slider can be clicked to a certain spot without either not moving or jumping between original and new value. 
- Volume slider smooth adjustment is available (not jittering when sliding track thumb).