### PR TITLE
Fix initial volume setting bug

### DIFF
--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -73,11 +73,13 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
     if (player.getMuted()) {
       setPlayerMuted(false);
       player.setMuted(false);
+      // A manual volume set call is needed here as unmuting does not change local volume to trigger the typical volume setting effect
+      player.setVolume(localVolume);
     } else {
       setPlayerMuted(true);
       player.setMuted(true);
     }
-  }, [player, signalUserActivity]);
+  }, [player, signalUserActivity, localVolume]);
 
   // Use this function to play a paused video, or pause a playing video. Intended to activate on clicking the video, or pressing spacebar
   const playOrPauseVideo = React.useCallback(() => {
@@ -102,12 +104,6 @@ export const VideoPlayer = ({ player, disableControls }: VideoPlayerProps) => {
       wrapperRef.current.focus();
     }
   };
-
-  React.useEffect(() => {
-    addEventListener("performSeek", () => {
-      console.log("Seek performed");
-    });
-  }, []);
 
   // A global keypress handler to allow the user to control the video regardless of where they are on the page.
   React.useEffect(() => {


### PR DESCRIPTION
This PR fixes the bug where initial player volume is not correctly set to 100 when unmuting the player. This was done by including a manual 'player.setVolume' call in the unmute function to ensure initial volume is correctly set on unmute. The following criteria are met:

- Volume is set to 100 when unmuting the player originally
- There must be some underlying initial effect when unmuting, or an initial effect to manually set volume to 100. The former might be preferred. 