### PR TITLE
Initial video styling

### DIFF
--- a/components/Layout/Nav.tsx
+++ b/components/Layout/Nav.tsx
@@ -6,7 +6,7 @@ import styles from "components/Layout/styles/Nav.module.css";
 export const Nav = () => {
   return (
     <nav role="navigation" className="nav">
-      <ul role="menubar" className={styles.navList}>
+      {/* <ul role="menubar" className={styles.navList}>
         <li role="menuitem" className={styles.navListItem}>
           Home
         </li>
@@ -19,7 +19,7 @@ export const Nav = () => {
         <li role="menuitem" className={styles.navListItem}>
           Log out
         </li>
-      </ul>
+      </ul> */}
     </nav>
   );
 };

--- a/features/players/components/styles/TwitchPlayer.module.css
+++ b/features/players/components/styles/TwitchPlayer.module.css
@@ -9,9 +9,11 @@
 
 .wrapperNormal {
   position: relative;
-  overflow: hidden;
   width: 100%;
-  padding-top: 56.25%;
+  height: 56.25vw;
+  max-height: calc(100vh - 169px);
+  min-height: 480px;
+  background: #000;
 }
 
 .wrapperTheater {

--- a/features/players/components/styles/TwitchPlayer.module.css
+++ b/features/players/components/styles/TwitchPlayer.module.css
@@ -10,8 +10,10 @@
 .wrapperNormal {
   position: relative;
   width: 100%;
+  /* Ensures 16:9 ratio */
   height: 56.25vw;
-  max-height: calc(100vh - 169px);
+  /* The second value measures height of video. 140 - 190px is a good range */
+  max-height: calc(100vh - 150px);
   min-height: 480px;
   background: #000;
 }


### PR DESCRIPTION
This PR finally addresses the unstyled initial video wrapper, switching to what is essentially YouTube's theatre mode as the initial mode of the video player. The following criteria are met:

- The video player initialises with a top aligned but horizontally centred video with black bars either side, forming a sort of pseudo-theatre mode.
- The player retains all normal theatre mode and full screen mode features. 
- The sidebar must be collapsible to properly allow this mode to work - this will be done in a separate task.