### PR TITLE
End of video

### DIFF
--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -47,6 +47,7 @@ export const VideoPlayer = ({
   const [playerMuted, setPlayerMuted] = React.useState(true);
   const [playerPaused, setPlayerPaused] = React.useState(false);
   const [theaterMode, setTheaterMode] = React.useState(false);
+  const [videoEnded, setVideoEnded] = React.useState(false);
 
   // Set the player volume according to local changes in volume. By working with the local volume state, we get a fluid UI as opposed to a laggy API interaction. It is fine to have a trace delay between local change and API player volume update.
   React.useEffect(() => {
@@ -74,7 +75,11 @@ export const VideoPlayer = ({
         // TODO: Avoid spoiler recommendations
         // TODO: Provide user with an indication we are at the end
         // TODO: Provide a replay functionality
-        console.log("video ended");
+        setVideoEnded(true);
+      });
+
+      player.addEventListener("seek", () => {
+        setVideoEnded(false);
       });
     }
   }, [player]);
@@ -248,6 +253,15 @@ export const VideoPlayer = ({
       wrapperRef={wrapperRef}
     >
       <div id="player"></div>
+      {player && (
+        <div
+          className={`${styles.endOverlay} ${videoEnded ? styles.show : ""}`}
+        >
+          <button className="replay" onClick={() => scheduleSeek(-Infinity)}>
+            Replay
+          </button>
+        </div>
+      )}
       <div
         className={`${styles.overlay} ${
           userActive || playerPaused ? "" : styles.overlayInactive

--- a/features/players/components/VideoPlayer.tsx
+++ b/features/players/components/VideoPlayer.tsx
@@ -65,6 +65,17 @@ export const VideoPlayer = ({
       player.addEventListener("pause", () => {
         setPlayerPaused(true);
       });
+
+      player.addEventListener("ended", () => {
+        // TODO: Ensure all seek indicators disappear
+        // TODO: Ensure current seek events are eliminated
+        // TODO: Ensure the video duration is set to accurate endpoint
+        // TODO: Avoid autoplay of further videos
+        // TODO: Avoid spoiler recommendations
+        // TODO: Provide user with an indication we are at the end
+        // TODO: Provide a replay functionality
+        console.log("video ended");
+      });
     }
   }, [player]);
 

--- a/features/players/components/styles/TwitchPlayer.module.css
+++ b/features/players/components/styles/TwitchPlayer.module.css
@@ -61,8 +61,20 @@
   pointer-events: none;
 }
 
-.overlayEnd {
+.endOverlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
   background-color: black;
+  opacity: 1;
+  display: none;
+  z-index: 10;
+}
+
+.show {
+  display: block;
 }
 
 .overlayInactive {

--- a/features/players/components/styles/TwitchPlayer.module.css
+++ b/features/players/components/styles/TwitchPlayer.module.css
@@ -68,13 +68,48 @@
   width: 100%;
   height: 100%;
   background-color: black;
-  opacity: 1;
+  opacity: 0;
   display: none;
   z-index: 10;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 2000ms ease;
 }
 
 .show {
-  display: block;
+  opacity: 1;
+  transition: none;
+}
+
+.replayMessage {
+  padding: 0.5rem;
+  background-color: transparent;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  gap: 0.5rem;
+}
+
+.replayIcon {
+  width: 3rem;
+  height: 3rem;
+  display: flex;
+  transform-origin: 50% 55%;
+  animation: spin 1500ms infinite ease-in-out;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(-360deg);
+  }
 }
 
 .overlayInactive {

--- a/features/players/hooks/useSeek.tsx
+++ b/features/players/hooks/useSeek.tsx
@@ -50,9 +50,16 @@ export const useSeek = (player: Player | null) => {
     }
   }, [player]);
 
+  const cancelSeek = React.useCallback(() => {
+    seekTimer.current = null;
+    setProjectedTime(null);
+    setSeekAmount(null);
+  }, []);
+
   return {
     scheduleSeek,
     projectedTime,
     seekAmount,
+    cancelSeek,
   };
 };

--- a/icons/ReplayIcon.tsx
+++ b/icons/ReplayIcon.tsx
@@ -1,0 +1,34 @@
+interface ReplayIconProps {
+  className?: string;
+  fill?: string;
+  testId?: string;
+}
+
+const ReplayIcon = ({
+  className,
+  fill = "#FFFFFF",
+  testId,
+}: ReplayIconProps) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      enableBackground="new 0 0 24 24"
+      viewBox="0 0 24 24"
+      className={className ? className : undefined}
+      data-testid={testId ? testId : undefined}
+      fill={fill}
+    >
+      <g>
+        <rect fill="none" height="24" width="24" />
+        <rect fill="none" height="24" width="24" />
+        <rect fill="none" height="24" width="24" />
+      </g>
+      <g>
+        <g />
+        <path d="M12,5V1L7,6l5,5V7c3.31,0,6,2.69,6,6s-2.69,6-6,6s-6-2.69-6-6H4c0,4.42,3.58,8,8,8s8-3.58,8-8S16.42,5,12,5z" />
+      </g>
+    </svg>
+  );
+};
+
+export default ReplayIcon;


### PR DESCRIPTION
This PR handles the end of vides (semi) gracefully, and certainly blocks all spoilers. The only viable way to handle spoilers was to auto-restart the video with a blocking overlay. It meets the following requirements:

- The video ends gracefully without showing any spoiler recommendations
- Video end effect is consistent across all platforms
- There is appropriate styling, e.g., black screen +/- a message to the use ("End"), or the option to replay.