### PR TITLE
Youtube player tooltip

### DIFF
--- a/features/players/components/styles/TwitchVideoDetails.module.css
+++ b/features/players/components/styles/TwitchVideoDetails.module.css
@@ -85,7 +85,7 @@
 
 .rightContainer {
   flex-shrink: 0;
-  width: 10rem;
+  /* width: 10rem; */
   display: flex;
   align-items: flex-end;
   flex-direction: column;
@@ -105,7 +105,7 @@
   padding: 0.75rem;
   border-radius: 6px;
   gap: 0.2rem;
-  width: 100%;
+  width: 10rem;
 }
 
 .youtubeLink {
@@ -121,7 +121,13 @@
   padding: 0.75rem;
   border-radius: 6px;
   gap: 0.2rem;
-  width: 100%;
+  width: 10rem;
+}
+
+.playerSwitchContainer {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .playerSwitchLink {
@@ -137,7 +143,7 @@
   padding: 0.5rem 0.75rem;
   border-radius: 6px;
   gap: 0.6rem;
-  width: 100%;
+  width: 10rem;
 }
 
 .twitchName {

--- a/features/players/components/styles/YouTubePlayerTooltip.module.css
+++ b/features/players/components/styles/YouTubePlayerTooltip.module.css
@@ -15,7 +15,7 @@
 
 .tooltipText {
   visibility: hidden;
-  /* width: 15.5rem; */
+  min-width: 16rem;
   background-color: #3d3d3d;
   color: #fff;
   text-align: left;
@@ -24,7 +24,7 @@
   border-radius: 6px;
   position: absolute;
   z-index: 1;
-  left: 125%;
+  right: 125%;
   top: 50%;
   margin-top: -0.05rem;
   transform: translateY(-50%);
@@ -40,12 +40,12 @@
   content: "";
   position: absolute;
   top: 50%;
-  right: 100%;
+  left: 100%;
   margin-top: -4px;
-  margin-left: -5px;
+  margin-left: 0px;
   border-width: 5px;
   border-style: solid;
-  border-color: transparent #555 transparent transparent;
+  border-color: transparent transparent transparent #555;
 }
 
 /* Show the tooltip text when you mouse over the tooltip container */

--- a/features/players/components/styles/YouTubePlayerTooltip.module.css
+++ b/features/players/components/styles/YouTubePlayerTooltip.module.css
@@ -1,0 +1,55 @@
+.tooltip {
+  position: relative;
+  display: inline-block;
+  line-height: 0;
+}
+
+.icon {
+  opacity: 0.5;
+  width: 22px;
+}
+
+.icon:hover {
+  opacity: 1;
+}
+
+.tooltipText {
+  visibility: hidden;
+  width: 15.5rem;
+  background-color: #3d3d3d;
+  color: #fff;
+  text-align: left;
+  font-size: 0.9rem;
+  padding: 0.6rem 0.75rem 0.75rem 0.9rem;
+  border-radius: 6px;
+  position: absolute;
+  z-index: 1;
+  left: 125%;
+  top: 50%;
+  margin-top: -0.05rem;
+  transform: translateY(-50%);
+  line-height: normal;
+
+  /* Fade in tooltip */
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+/* Tooltip arrow */
+.tooltipText::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 100%;
+  margin-top: -4px;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: transparent #555 transparent transparent;
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+.tooltip:hover .tooltipText {
+  visibility: visible;
+  opacity: 1;
+}

--- a/features/players/components/styles/YouTubePlayerTooltip.module.css
+++ b/features/players/components/styles/YouTubePlayerTooltip.module.css
@@ -15,7 +15,7 @@
 
 .tooltipText {
   visibility: hidden;
-  width: 15.5rem;
+  /* width: 15.5rem; */
   background-color: #3d3d3d;
   color: #fff;
   text-align: left;

--- a/features/players/components/styles/YouTubePlayerTooltip.module.css
+++ b/features/players/components/styles/YouTubePlayerTooltip.module.css
@@ -15,9 +15,9 @@
 
 .tooltipText {
   visibility: hidden;
-  min-width: 16rem;
-  background-color: #3d3d3d;
-  color: #fff;
+  min-width: 20rem;
+  background-color: #16161a;
+  color: #c7d1db;
   text-align: left;
   font-size: 0.9rem;
   padding: 0.6rem 0.75rem 0.75rem 0.9rem;
@@ -45,7 +45,7 @@
   margin-left: 0px;
   border-width: 5px;
   border-style: solid;
-  border-color: transparent transparent transparent #555;
+  border-color: transparent transparent transparent #16161a;
 }
 
 /* Show the tooltip text when you mouse over the tooltip container */

--- a/features/players/components/video-details/YouTubeVideoDetails.tsx
+++ b/features/players/components/video-details/YouTubeVideoDetails.tsx
@@ -102,10 +102,10 @@ export const YouTubeVideoDetails = ({
               </div>
             ) : (
               <>
-                <div>
+                <div className={styles.playerSwitchContainer}>
                   <YouTubePlayerTooltip
                     showTooltip={true}
-                    tooltipText="Lorem ipsum"
+                    tooltipText="The default YouTube player uses Resports' player controls, but does not allow the user to change video quality. Switch to the custom player to use YouTube's naitve player controls, which allow for quality change. Once the quality is adjusted, it is recommended to then enable Resports controls while in the custom player mode."
                     ariaLabel="Show more information about the different YouTube video players"
                   />
                   <Link

--- a/features/players/components/video-details/YouTubeVideoDetails.tsx
+++ b/features/players/components/video-details/YouTubeVideoDetails.tsx
@@ -7,6 +7,7 @@ import { timeAgo } from "config/timeAgoFormatter";
 import { useGetYouTubeVideoDetails } from "features/players/hooks/useGetYouTubeVideoDetails";
 import YouTubeFullIcon from "icons/YouTubeFullIcon";
 import SwitchPlayerIcon from "icons/SwitchPlayerIcon";
+import YouTubePlayerTooltip from "../youtube-player/YouTubePlayerTooltip";
 
 interface YouTubeVideoDetailsProps {
   videoId: string;
@@ -83,23 +84,38 @@ export const YouTubeVideoDetails = ({
               Watch on
               <YouTubeFullIcon className={styles.youtubeIcon} />
             </Link>
+
             {defaultPlayer ? (
-              <Link
-                href={`/youtube/video/${videoId}/native-player`}
-                className={styles.playerSwitchLink}
-              >
-                <SwitchPlayerIcon className={styles.switchIcon} />
-                Custom player
-              </Link>
-            ) : (
-              <>
+              <div className={styles.playerSwitchContainer}>
+                <YouTubePlayerTooltip
+                  showTooltip={true}
+                  tooltipText="Lorem ipsum"
+                  ariaLabel="Show more information about the different YouTube video players"
+                />
                 <Link
-                  href={`/youtube/video/${videoId}`}
+                  href={`/youtube/video/${videoId}/native-player`}
                   className={styles.playerSwitchLink}
                 >
                   <SwitchPlayerIcon className={styles.switchIcon} />
-                  Default player
+                  Custom player
                 </Link>
+              </div>
+            ) : (
+              <>
+                <div>
+                  <YouTubePlayerTooltip
+                    showTooltip={true}
+                    tooltipText="Lorem ipsum"
+                    ariaLabel="Show more information about the different YouTube video players"
+                  />
+                  <Link
+                    href={`/youtube/video/${videoId}`}
+                    className={styles.playerSwitchLink}
+                  >
+                    <SwitchPlayerIcon className={styles.switchIcon} />
+                    Default player
+                  </Link>
+                </div>
                 <div className={styles.toggleSwitch}>
                   <label className={styles.switch}>
                     <span className={styles.labelText}>Enable controls</span>

--- a/features/players/components/video-details/YouTubeVideoDetails.tsx
+++ b/features/players/components/video-details/YouTubeVideoDetails.tsx
@@ -88,7 +88,7 @@ export const YouTubeVideoDetails = ({
             {defaultPlayer ? (
               <div className={styles.playerSwitchContainer}>
                 <InfoTooltip
-                  tooltipText="Lorem ipsum"
+                  tooltipText="The default YouTube player uses Resports' player controls, but does not allow the user to change video quality. Switch to the custom player to use YouTube's naitve player controls, which allow for quality change."
                   ariaLabel="Show more information about the different YouTube video players"
                 />
                 <Link
@@ -103,7 +103,7 @@ export const YouTubeVideoDetails = ({
               <>
                 <div className={styles.playerSwitchContainer}>
                   <InfoTooltip
-                    tooltipText="The default YouTube player uses Resports' player controls, but does not allow the user to change video quality. Switch to the custom player to use YouTube's naitve player controls, which allow for quality change. Once the quality is adjusted, it is recommended to then enable Resports controls while in the custom player mode."
+                    tooltipText="The default YouTube player uses Resports' player controls, but does not allow the user to change video quality. Switch to the custom player to use YouTube's naitve player controls, which allow for quality change."
                     ariaLabel="Show more information about the different YouTube video players"
                   />
                   <Link

--- a/features/players/components/video-details/YouTubeVideoDetails.tsx
+++ b/features/players/components/video-details/YouTubeVideoDetails.tsx
@@ -7,7 +7,7 @@ import { timeAgo } from "config/timeAgoFormatter";
 import { useGetYouTubeVideoDetails } from "features/players/hooks/useGetYouTubeVideoDetails";
 import YouTubeFullIcon from "icons/YouTubeFullIcon";
 import SwitchPlayerIcon from "icons/SwitchPlayerIcon";
-import YouTubePlayerTooltip from "../youtube-player/YouTubePlayerTooltip";
+import { InfoTooltip } from "../youtube-player/InfoTooltip";
 
 interface YouTubeVideoDetailsProps {
   videoId: string;
@@ -87,8 +87,7 @@ export const YouTubeVideoDetails = ({
 
             {defaultPlayer ? (
               <div className={styles.playerSwitchContainer}>
-                <YouTubePlayerTooltip
-                  showTooltip={true}
+                <InfoTooltip
                   tooltipText="Lorem ipsum"
                   ariaLabel="Show more information about the different YouTube video players"
                 />
@@ -103,8 +102,7 @@ export const YouTubeVideoDetails = ({
             ) : (
               <>
                 <div className={styles.playerSwitchContainer}>
-                  <YouTubePlayerTooltip
-                    showTooltip={true}
+                  <InfoTooltip
                     tooltipText="The default YouTube player uses Resports' player controls, but does not allow the user to change video quality. Switch to the custom player to use YouTube's naitve player controls, which allow for quality change. Once the quality is adjusted, it is recommended to then enable Resports controls while in the custom player mode."
                     ariaLabel="Show more information about the different YouTube video players"
                   />

--- a/features/players/components/youtube-player/InfoTooltip.tsx
+++ b/features/players/components/youtube-player/InfoTooltip.tsx
@@ -2,26 +2,16 @@ import QuestionMarkIcon from "icons/QuestionMarkIcon";
 import React from "react";
 import styles from "features/players/components/styles/YouTubePlayerTooltip.module.css";
 
-interface YouTubePlayerTooltipProps {
-  showTooltip: boolean;
+interface InfoTooltipProps {
   tooltipText: string;
   ariaLabel: string;
 }
 
-const YouTubePlayerTooltip = ({
-  showTooltip,
-  tooltipText,
-  ariaLabel,
-}: YouTubePlayerTooltipProps) => {
+export const InfoTooltip = ({ tooltipText, ariaLabel }: InfoTooltipProps) => {
   return (
-    <div
-      className={`${styles.tooltip} ${showTooltip ? styles.show : styles.hide}`}
-      aria-label={ariaLabel}
-    >
+    <div className={`${styles.tooltip}`} aria-label={ariaLabel}>
       <QuestionMarkIcon className={styles.icon} />
       <p className={styles.tooltipText}>{tooltipText}</p>
     </div>
   );
 };
-
-export default YouTubePlayerTooltip;

--- a/features/players/components/youtube-player/YouTubePlayerTooltip.tsx
+++ b/features/players/components/youtube-player/YouTubePlayerTooltip.tsx
@@ -1,0 +1,23 @@
+import QuestionMarkIcon from "icons/QuestionMarkIcon";
+import React from "react";
+import styles from "features/players/components/styles/YouTubePlayerTooltip.module.css";
+
+interface TooltipProps {
+  showTooltip: boolean;
+  tooltipText: string;
+  ariaLabel: string;
+}
+
+const Tooltip = ({ showTooltip, tooltipText, ariaLabel }: TooltipProps) => {
+  return (
+    <div
+      className={`${styles.tooltip} ${showTooltip ? styles.show : styles.hide}`}
+      aria-label={ariaLabel}
+    >
+      <QuestionMarkIcon className={styles.icon} />
+      <p className={styles.tooltipText}>{tooltipText}</p>
+    </div>
+  );
+};
+
+export default Tooltip;

--- a/features/players/components/youtube-player/YouTubePlayerTooltip.tsx
+++ b/features/players/components/youtube-player/YouTubePlayerTooltip.tsx
@@ -2,13 +2,17 @@ import QuestionMarkIcon from "icons/QuestionMarkIcon";
 import React from "react";
 import styles from "features/players/components/styles/YouTubePlayerTooltip.module.css";
 
-interface TooltipProps {
+interface YouTubePlayerTooltipProps {
   showTooltip: boolean;
   tooltipText: string;
   ariaLabel: string;
 }
 
-const Tooltip = ({ showTooltip, tooltipText, ariaLabel }: TooltipProps) => {
+const YouTubePlayerTooltip = ({
+  showTooltip,
+  tooltipText,
+  ariaLabel,
+}: YouTubePlayerTooltipProps) => {
   return (
     <div
       className={`${styles.tooltip} ${showTooltip ? styles.show : styles.hide}`}
@@ -20,4 +24,4 @@ const Tooltip = ({ showTooltip, tooltipText, ariaLabel }: TooltipProps) => {
   );
 };
 
-export default Tooltip;
+export default YouTubePlayerTooltip;

--- a/icons/QuestionMarkIcon.tsx
+++ b/icons/QuestionMarkIcon.tsx
@@ -1,0 +1,40 @@
+interface QuestionMarkIconProps {
+  className?: string;
+  fill?: string;
+  testId?: string;
+}
+
+const QuestionMarkIcon = ({
+  className,
+  fill = "#FFFFFF",
+  testId,
+}: QuestionMarkIconProps) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512"
+      className={className ? className : undefined}
+      data-testid={testId ? testId : undefined}
+      fill={fill}
+    >
+      <path
+        d="M256 80a176 176 0 10176 176A176 176 0 00256 80z"
+        fill="none"
+        stroke="currentColor"
+        strokeMiterlimit="10"
+        strokeWidth="32"
+      />
+      <path
+        d="M200 202.29s.84-17.5 19.57-32.57C230.68 160.77 244 158.18 256 158c10.93-.14 20.69 1.67 26.53 4.45 10 4.76 29.47 16.38 29.47 41.09 0 26-17 37.81-36.37 50.8S251 281.43 251 296"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeMiterlimit="10"
+        strokeWidth="28"
+      />
+      <circle cx="250" cy="348" r="20" />
+    </svg>
+  );
+};
+
+export default QuestionMarkIcon;


### PR DESCRIPTION
This PR addresses the YT player switch toggle by means of explaining why each player exists and places this information in a toggle-able tooltip.