### PR TITLE
Update post login handler with new API endpoint and routes

### DIFF
--- a/auth0/postLoginHandler.js
+++ b/auth0/postLoginHandler.js
@@ -32,7 +32,7 @@ exports.onExecutePostLogin = async (event, api) => {
   // Use JWT retrieved above to call API route for upserting user to custom Postgres database
   const upsertUserRequest = {
     method: "POST",
-    url: `https://uhojd6ug1l.execute-api.ap-southeast-2.amazonaws.com/users`,
+    url: `${event.secrets.AWS_API_ENDPOINT}/users/${event.user.user_id}`,
     headers: {
       "content-type": "application/json",
       Authorization: `Bearer ${tokenData.access_token}`,

--- a/components/Auth0/Profile.tsx
+++ b/components/Auth0/Profile.tsx
@@ -18,7 +18,7 @@ const Profile = () => {
 
     getUserMetadata();
 
-    console.log(user);
+    console.log(JSON.stringify(user));
   }, [getAccessTokenSilently, user]);
 
   if (isLoading) {


### PR DESCRIPTION
This PR makes a small change to the post login handler to remain consistent with AWS changes. If the post login handler throws an error, the OAuth consent flow is interrupted and the user cannot gain an access token.