### PR TITLE
Removal of next/image 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,5 +6,8 @@
     "prettier"
   ],
   "plugins": ["@typescript-eslint"],
-  "parser": "@typescript-eslint/parser"
+  "parser": "@typescript-eslint/parser",
+  "rules": {
+    "@next/next/no-img-element": "off"
+  }
 }

--- a/auth0/postLoginHandler.js
+++ b/auth0/postLoginHandler.js
@@ -29,17 +29,20 @@ exports.onExecutePostLogin = async (event, api) => {
 
   const { data: tokenData } = await axios(tokenRequest);
 
-  // Use JWT retrieved above to call API route for upserting user to custom Postgres database
-  const upsertUserRequest = {
+  const addUserRequest = {
     method: "POST",
-    url: `${event.secrets.AWS_API_ENDPOINT}/users/${event.user.user_id}`,
+    url: `${event.secrets.AWS_API_ENDPOINT}users`,
     headers: {
       "content-type": "application/json",
       Authorization: `Bearer ${tokenData.access_token}`,
     },
-    data: event.user,
+    data: {
+      email: event.user.email,
+      email_verified: event.user.email_verified,
+      user_id: event.user.user_id,
+    },
   };
 
-  const { data: awsData } = await axios(upsertUserRequest);
-  console.log(awsData);
+  const res = await axios(addUserRequest);
+  console.log(res);
 };

--- a/features/channels/components/twitch-channel/TwitchChannelPage.tsx
+++ b/features/channels/components/twitch-channel/TwitchChannelPage.tsx
@@ -1,5 +1,4 @@
 import { useGetTwitchChannel } from "features/channels/hooks/useGetTwitchChannel";
-import Image from "next/image";
 import { TwitchChannelVideos } from "features/channels";
 
 interface TwitchChannelProps {
@@ -20,14 +19,14 @@ export const TwitchChannelPage = ({ channelId }: TwitchChannelProps) => {
           <div>
             <h2>{data.channelData.displayName}</h2>
             <p>{data.userData.description}</p>
-            <Image
+            <img
               src={data.userData.profilePictureUrl}
               alt={`${data.channelData.displayName} channel thumbnail`}
               height={100}
               width={100}
             />
             {data.userData.offlinePlaceholderUrl && (
-              <Image
+              <img
                 src={data.userData.offlinePlaceholderUrl}
                 alt={`${data.channelData.displayName} channel banner`}
                 height={100}

--- a/features/channels/components/youtube-channel/YouTubeChannel.tsx
+++ b/features/channels/components/youtube-channel/YouTubeChannel.tsx
@@ -1,7 +1,5 @@
 import { useGetYouTubeChannel } from "features/channels/hooks/useGetYouTubeChannel";
-import Image from "next/image";
 import { YouTubeChannelVideos } from "features/channels";
-import { useEffect } from "react";
 
 interface YouTubeChannelProps {
   channelId: string;
@@ -24,7 +22,7 @@ const YouTubeChannel = ({ channelId }: YouTubeChannelProps) => {
                 <div>
                   <h2>{data.channelData.snippet.title}</h2>
                   <p>{data.channelData.snippet.description}</p>
-                  <Image
+                  <img
                     src={data.channelData.snippet.thumbnails.medium.url}
                     alt={`${data.channelData.snippet.title} channel thumbnail`}
                     height={100}
@@ -32,7 +30,7 @@ const YouTubeChannel = ({ channelId }: YouTubeChannelProps) => {
                   />
 
                   {/* Note: the bannerUrl has a max res of 512 * 288 and will likely be remove altogether later x  */}
-                  <Image
+                  <img
                     src={
                       data.channelData.brandingSettings.image.bannerExternalUrl
                     }

--- a/features/channels/components/youtube-channel/YouTubeVideoListing.tsx
+++ b/features/channels/components/youtube-channel/YouTubeVideoListing.tsx
@@ -1,6 +1,5 @@
 import { YouTubeVideoResult } from "types/youtubeAPITypes";
 import styles from "features/channels/components/styles/YouTubeVideoListing.module.css";
-import Image from "next/image";
 import { convertYouTubeVideoDuration } from "utils/videoDurationConversion";
 import Link from "next/link";
 import { timeAgo } from "config/timeAgoFormatter";

--- a/features/players/components/video-details/TwitchVideoDetails.tsx
+++ b/features/players/components/video-details/TwitchVideoDetails.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Image from "next/image";
 import styles from "features/players/components/styles/TwitchVideoDetails.module.css";
 import Link from "next/link";
 import { timeAgo } from "config/timeAgoFormatter";
@@ -41,7 +40,7 @@ export const TwitchVideoDetails = ({
               className={styles.imageLink}
             >
               <span className={styles.srOnly}>{userData.displayName}</span>
-              <Image
+              <img
                 alt={`${userData.displayName} thumbnail`}
                 src={userData.profilePictureUrl}
                 width={55}

--- a/features/players/components/video-details/TwitchVideoDetailsOverlay.tsx
+++ b/features/players/components/video-details/TwitchVideoDetailsOverlay.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import styles from "features/players/components/styles/TwitchVideoDetailsOverlay.module.css";
 import Link from "next/link";
-import Image from "next/image";
 import { TwitchVideo } from "features/channels";
 import { Routes } from "config/routes";
 
@@ -23,7 +22,7 @@ export const TwitchVideoDetailsOverlay = ({
           className={styles.imageLink}
         >
           <span className={styles.srOnly}>{userData.displayName}</span>
-          <Image
+          <img
             alt={`${userData.displayName} thumbnail`}
             src={userData.profilePictureUrl}
             width={45}

--- a/features/players/components/video-details/YouTubeVideoDetails.tsx
+++ b/features/players/components/video-details/YouTubeVideoDetails.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Image from "next/image";
 import styles from "features/players/components/styles/TwitchVideoDetails.module.css";
 import Link from "next/link";
 import { timeAgo } from "config/timeAgoFormatter";
@@ -58,7 +57,7 @@ export const YouTubeVideoDetails = ({
                 <span className={styles.srOnly}>
                   {data.channelData.snippet.title}
                 </span>
-                <Image
+                <img
                   alt={`${data.channelData.snippet.title} thumbnail`}
                   src={data.channelData.snippet.thumbnails.default.url}
                   width={55}

--- a/features/search/components/twitch-search/TwitchChannelResult.tsx
+++ b/features/search/components/twitch-search/TwitchChannelResult.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import { HelixChannelSearchResult } from "@twurple/api/lib/api/helix/search/HelixChannelSearchResult";
 import styles from "features/search/components/styles/TwitchSearchResult.module.css";
 import Link from "next/link";
@@ -14,7 +13,7 @@ export const TwitchChannelResult = ({
   return (
     <div className={styles.channel}>
       <div className={styles.imgContainer}>
-        <Image
+        <img
           src={channelData.thumbnailUrl}
           alt={`${channelData.displayName} channel thumbnail`}
           height={100}

--- a/features/search/components/youtube-search/YouTubeChannelResult.tsx
+++ b/features/search/components/youtube-search/YouTubeChannelResult.tsx
@@ -1,5 +1,4 @@
 import { YouTubeSearchResultSnippet } from "types/youtubeAPITypes";
-import Image from "next/image";
 import styles from "features/search/components/styles/YouTubeSearchResult.module.css";
 import Link from "next/link";
 import { Routes } from "config/routes";
@@ -14,7 +13,7 @@ export const YouTubeChannelResult = ({
   return (
     <div className={styles.channel}>
       <div>
-        <Image
+        <img
           src={channelData.thumbnails.medium.url}
           alt={`${channelData.channelTitle} channel thumbnail`}
           height={100}

--- a/utils/ImageWithFallback.tsx
+++ b/utils/ImageWithFallback.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
-import Image, { ImageProps } from "next/image";
 
-interface ImageWithFallbackProps extends ImageProps {
+interface ImageWithFallbackProps
+  extends React.ImgHTMLAttributes<HTMLImageElement> {
   fallbackSrc: string;
   alt: string;
 }
@@ -11,7 +11,7 @@ const ImageWithFallback = (props: ImageWithFallbackProps) => {
   const [imgSrc, setImgSrc] = useState(src);
 
   return (
-    <Image
+    <img
       {...rest}
       alt={alt}
       src={imgSrc ? imgSrc : fallbackSrc}


### PR DESCRIPTION
This PR converts all `Image` tags provided by Next.js to standard `<img>` HTML tags. This was done to avoid surpassing image optimisation limits on Vercel's free Hobby plan. Furthermore, we are dealing generally with lots of small images, so optimisation may not be critical.