### PR TITLE
Split channel platforms in saved channel list

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/deploym
 
 # TODOS
 
-- Cursor disappears when moving into video overlay from the top (e.g. can't change channel search select)
+- Cursor disappears when moving into video overlay from the top (e.g. can't change channel search select). NOTE: This only occurs on the Twitch player lol

--- a/components/Layout/Sidebar.tsx
+++ b/components/Layout/Sidebar.tsx
@@ -23,10 +23,7 @@ export const Sidebar = ({ showSidebar, closeSidebar }: SidebarProps) => {
         <HamburgerIcon className={styles.hamburgerIcon} />
       </button>
       <div className={styles.sidebarBody}>
-        <div className={styles.sidebarHeader}>Saved channels</div>
-        <div onClick={closeSidebar}>
-          <SidebarSavedChannelsList />
-        </div>
+        <SidebarSavedChannelsList closeSidebar={closeSidebar} />
       </div>
     </div>
   );

--- a/features/saved-channels/components/saved-channel-list/SidebarSavedChannelList.tsx
+++ b/features/saved-channels/components/saved-channel-list/SidebarSavedChannelList.tsx
@@ -1,10 +1,17 @@
 import { LoadingSpinner } from "components/spinner";
 import { useGetSavedChannels } from "features/saved-channels/api/useSavedChannels";
 import { toast } from "react-hot-toast";
-import { CombinedChannelList } from "./CombinedChannelList";
 import styles from "../styles/SidebarSavedChannelList.module.css";
+import { YouTubeSavedChannelList } from "./YouTubeSavedChannelList";
+import { TwitchSavedChannelList } from "./TwitchSavedChannelList";
+import TwitchNameIcon from "icons/TwitchNameIcon";
+import YouTubeFullIcon from "icons/YouTubeFullIcon";
 
-export const SidebarSavedChannelsList = () => {
+export const SidebarSavedChannelsList = ({
+  closeSidebar,
+}: {
+  closeSidebar: () => void;
+}) => {
   const {
     data: savedChannels,
     isLoading: isSavedChannelsLoading,
@@ -12,13 +19,20 @@ export const SidebarSavedChannelsList = () => {
   } = useGetSavedChannels();
 
   if (isSavedChannelsError) {
-    toast.error("Error: Unable to get saved channels.");
+    toast.error("Unable to get saved channels.");
   }
 
   if (isSavedChannelsLoading) {
     return (
-      <div className={styles.loading}>
-        <LoadingSpinner />
+      <div>
+        <TwitchNameIcon fill="#9147FF" className={styles.twitchHeader} />
+        <div className={styles.loading}>
+          <LoadingSpinner />
+        </div>
+        <YouTubeFullIcon className={styles.youtubeHeader} />
+        <div className={styles.loading}>
+          <LoadingSpinner />
+        </div>
       </div>
     );
   }
@@ -35,9 +49,15 @@ export const SidebarSavedChannelsList = () => {
   );
 
   return (
-    <CombinedChannelList
-      youtubeChannelIds={youtubeChannelIds}
-      twitchChannelIds={twitchChannelIds}
-    />
+    <div>
+      <TwitchNameIcon fill="#9147FF" className={styles.twitchHeader} />
+      <div className={styles.savedChannelList} onClick={closeSidebar}>
+        <TwitchSavedChannelList channelIds={twitchChannelIds} />
+      </div>
+      <YouTubeFullIcon className={styles.youtubeHeader} />
+      <div className={styles.savedChannelList} onClick={closeSidebar}>
+        <YouTubeSavedChannelList channelIds={youtubeChannelIds} />
+      </div>
+    </div>
   );
 };

--- a/features/saved-channels/components/saved-channel-list/TwitchSavedChannelList.tsx
+++ b/features/saved-channels/components/saved-channel-list/TwitchSavedChannelList.tsx
@@ -1,0 +1,54 @@
+import { Routes } from "config/routes";
+import { useGetTwitchChannels } from "features/channels/hooks/useGetTwitchChannels";
+import { SavedChannelCard } from "./SavedChannelCard";
+import { toast } from "react-hot-toast";
+import styles from "../styles/SidebarSavedChannelList.module.css";
+import { LoadingSpinner } from "components/spinner";
+
+export const TwitchSavedChannelList = ({
+  channelIds,
+}: {
+  channelIds: string[];
+}) => {
+  const {
+    data: channels,
+    isLoading,
+    isError,
+  } = useGetTwitchChannels(channelIds);
+
+  if (isLoading) {
+    return (
+      <div className={styles.loading}>
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (isError) {
+    toast.error("Unable to get saved Twitch channels.");
+  }
+
+  if (!channels) {
+    return null;
+  }
+
+  const sortedChannels = channels.sort((a, b) =>
+    a.channelData.displayName
+      .toLowerCase()
+      .localeCompare(b.channelData.displayName.toLowerCase())
+  );
+
+  return (
+    <div>
+      {sortedChannels.map((channel) => (
+        <SavedChannelCard
+          key={channel.channelData.id}
+          thumbnailUrl={channel.userData.profilePictureUrl}
+          title={channel.channelData.displayName}
+          route={`${Routes.twitch.channel}/${channel.channelData.id}`}
+          live={channel.isLive}
+        />
+      ))}
+    </div>
+  );
+};

--- a/features/saved-channels/components/saved-channel-list/YouTubeSavedChannelList.tsx
+++ b/features/saved-channels/components/saved-channel-list/YouTubeSavedChannelList.tsx
@@ -1,0 +1,51 @@
+import { Routes } from "config/routes";
+import { SavedChannelCard } from "./SavedChannelCard";
+import { toast } from "react-hot-toast";
+import styles from "../styles/SidebarSavedChannelList.module.css";
+import { LoadingSpinner } from "components/spinner";
+import { useGetYouTubeChannels } from "features/channels/hooks/useGetYouTubeChannels";
+
+export const YouTubeSavedChannelList = ({
+  channelIds,
+}: {
+  channelIds: string[];
+}) => {
+  const {
+    data: channels,
+    isLoading,
+    isError,
+  } = useGetYouTubeChannels(channelIds);
+
+  if (isLoading) {
+    return (
+      <div className={styles.loading}>
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (isError) {
+    toast.error("Unable to get saved YouTube channels.");
+  }
+
+  if (!channels) {
+    return null;
+  }
+
+  const sortedChannels = channels.sort((a, b) =>
+    a.snippet.title.toLowerCase().localeCompare(b.snippet.title.toLowerCase())
+  );
+
+  return (
+    <div>
+      {sortedChannels.map((channel) => (
+        <SavedChannelCard
+          key={channel.id}
+          thumbnailUrl={channel.snippet.thumbnails.medium.url}
+          title={channel.snippet.title}
+          route={`${Routes.youtube.channel}/${channel.id}`}
+        />
+      ))}
+    </div>
+  );
+};

--- a/features/saved-channels/components/styles/SidebarSavedChannelList.module.css
+++ b/features/saved-channels/components/styles/SidebarSavedChannelList.module.css
@@ -1,7 +1,23 @@
 .loading {
-  padding-top: 1rem;
+  padding: 1.5rem 0 3rem 0;
   display: flex;
   align-items: center;
   justify-content: center;
   width: 100%;
+}
+
+.twitchHeader {
+  padding: 0.5rem 0 0.5rem 0.5rem;
+  font-weight: 500;
+  width: 70px;
+}
+
+.youtubeHeader {
+  padding: 0.25rem 0 0.5rem 0.5rem;
+  font-weight: 500;
+  width: 80px;
+}
+
+.savedChannelList {
+  padding-bottom: 1.1rem;
 }


### PR DESCRIPTION
This PR splits the YouTube channels from the Twitch channels in the saved channel list. This was to avoid confusion and duplication by having a combined list, where it would be easy to accidentally end up on the wrong platform, with potential spoilers.