### PR TITLE
Add recently viewed channels

### DIFF
--- a/features/recently-viewed-channels/components/RecentlyViewedChannels.tsx
+++ b/features/recently-viewed-channels/components/RecentlyViewedChannels.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { useRecentlyViewedChannels } from "../hooks/useRecentlyViewedChannels";
+
+export const RecentlyViewedChannels = () => {
+  const { recentlyViewedChannels, clearRecentChannels } =
+    useRecentlyViewedChannels();
+
+  return (
+    <div>
+      <button onClick={clearRecentChannels}>
+        Clear Recently Viewed Channels
+      </button>
+      {recentlyViewedChannels.length > 0 ? (
+        <ul>
+          {recentlyViewedChannels.map((channel) => (
+            <li key={channel.channel_id}>
+              {channel.platform} - {channel.channel_id}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No recently viewed channels</p>
+      )}
+    </div>
+  );
+};

--- a/features/recently-viewed-channels/components/RecentlyViewedChannels.tsx
+++ b/features/recently-viewed-channels/components/RecentlyViewedChannels.tsx
@@ -7,6 +7,7 @@ import { useRecentlyViewedChannels } from "../hooks/useRecentlyViewedChannels";
 import styles from "features/saved-channels/components/styles/SidebarSavedChannelList.module.css";
 import { TwitchChannel } from "features/channels";
 import { YouTubeChannelSearchResult } from "types/youtubeAPITypes";
+import { Button } from "components/button";
 
 export const RecentlyViewedChannels = () => {
   const { recentlyViewedChannels, clearRecentChannels } =
@@ -61,6 +62,7 @@ export const RecentlyViewedChannels = () => {
 
   return (
     <div>
+      <h2>Recently viewed channels</h2>
       <TwitchNameIcon fill="#9147FF" className={styles.twitchHeader} />
       <div className={styles.savedChannelList}>
         {twitchChannelIds.length > 0 ? (
@@ -69,7 +71,7 @@ export const RecentlyViewedChannels = () => {
             sortFn={sortTwitchChannelsByReferenceArray}
           />
         ) : (
-          <p className={styles.subheader}>No saved channels</p>
+          <p className={styles.subheader}>No recently viewed</p>
         )}
       </div>
       <YouTubeFullIcon className={styles.youtubeHeader} />
@@ -80,9 +82,10 @@ export const RecentlyViewedChannels = () => {
             sortFn={sortYouTubeChannelsByReferenceArray}
           />
         ) : (
-          <p className={styles.subheader}>No saved channels</p>
+          <p className={styles.subheader}>No recently viewed</p>
         )}
       </div>
+      <Button onClick={clearRecentChannels}>Clear recently viewed</Button>
     </div>
   );
 };

--- a/features/recently-viewed-channels/components/RecentlyViewedChannels.tsx
+++ b/features/recently-viewed-channels/components/RecentlyViewedChannels.tsx
@@ -1,26 +1,88 @@
+import { TwitchSavedChannelList } from "features/saved-channels/components/saved-channel-list/TwitchSavedChannelList";
+import { YouTubeSavedChannelList } from "features/saved-channels/components/saved-channel-list/YouTubeSavedChannelList";
+import TwitchNameIcon from "icons/TwitchNameIcon";
+import YouTubeFullIcon from "icons/YouTubeFullIcon";
 import React from "react";
 import { useRecentlyViewedChannels } from "../hooks/useRecentlyViewedChannels";
+import styles from "features/saved-channels/components/styles/SidebarSavedChannelList.module.css";
+import { TwitchChannel } from "features/channels";
+import { YouTubeChannelSearchResult } from "types/youtubeAPITypes";
 
 export const RecentlyViewedChannels = () => {
   const { recentlyViewedChannels, clearRecentChannels } =
     useRecentlyViewedChannels();
 
+  // Sorts an array of channels to 'match' a reference array (i.e. the recentlyViewedChannels order)
+  const sortTwitchChannelsByReferenceArray = (
+    a: TwitchChannel,
+    b: TwitchChannel
+  ) => {
+    const indexA = recentlyViewedChannels.findIndex(
+      (ref) => ref.channel_id === a.channelData.id
+    );
+    const indexB = recentlyViewedChannels.findIndex(
+      (ref) => ref.channel_id === b.channelData.id
+    );
+
+    if (indexA === -1) return 1;
+    if (indexB === -1) return -1;
+
+    return indexA - indexB;
+  };
+
+  // Sorts an array of channels to 'match' a reference array (i.e. the recentlyViewedChannels order)
+  const sortYouTubeChannelsByReferenceArray = (
+    a: YouTubeChannelSearchResult,
+    b: YouTubeChannelSearchResult
+  ) => {
+    const indexA = recentlyViewedChannels.findIndex(
+      (ref) => ref.channel_id === a.id
+    );
+    const indexB = recentlyViewedChannels.findIndex(
+      (ref) => ref.channel_id === b.id
+    );
+
+    if (indexA === -1) return 1;
+    if (indexB === -1) return -1;
+
+    return indexA - indexB;
+  };
+
+  if (recentlyViewedChannels.length === 0) {
+    return <div>No recently viewed</div>;
+  }
+
+  const twitchChannelIds = recentlyViewedChannels.flatMap((channel) =>
+    channel.platform === "twitch" ? [channel.channel_id] : []
+  );
+  const youtubeChannelIds = recentlyViewedChannels.flatMap((channel) =>
+    channel.platform === "youtube" ? [channel.channel_id] : []
+  );
+
   return (
     <div>
-      <button onClick={clearRecentChannels}>
-        Clear Recently Viewed Channels
-      </button>
-      {recentlyViewedChannels.length > 0 ? (
-        <ul>
-          {recentlyViewedChannels.map((channel) => (
-            <li key={channel.channel_id}>
-              {channel.platform} - {channel.channel_id}
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p>No recently viewed channels</p>
-      )}
+      <TwitchNameIcon fill="#9147FF" className={styles.twitchHeader} />
+      <div className={styles.savedChannelList}>
+        {twitchChannelIds.length > 0 ? (
+          <TwitchSavedChannelList
+            channelIds={twitchChannelIds}
+            sortFn={sortTwitchChannelsByReferenceArray}
+          />
+        ) : (
+          <p className={styles.subheader}>No saved channels</p>
+        )}
+      </div>
+      <YouTubeFullIcon className={styles.youtubeHeader} />
+      <div className={styles.savedChannelList}>
+        {youtubeChannelIds.length > 0 ? (
+          <YouTubeSavedChannelList
+            channelIds={youtubeChannelIds}
+            sortFn={sortYouTubeChannelsByReferenceArray}
+          />
+        ) : (
+          <p className={styles.subheader}>No saved channels</p>
+        )}
+      </div>
     </div>
   );
 };

--- a/features/recently-viewed-channels/hooks/useAddChannelToRecent.tsx
+++ b/features/recently-viewed-channels/hooks/useAddChannelToRecent.tsx
@@ -2,7 +2,12 @@ import { useEffect } from "react";
 import { Channel } from "types/backendAPITypes";
 import { useRecentlyViewedChannels } from "./useRecentlyViewedChannels";
 
-export function useAddChannelToRecentOnMount(channel: Channel) {
+/**
+ * A hook that adds the specified channel to the recently viewed channels list on mount.
+ *
+ * @param {Channel} channel - The channel to add to the recent list.
+ */
+export function useAddChannelToRecent(channel: Channel) {
   const { addChannelToRecent } = useRecentlyViewedChannels();
 
   useEffect(() => {

--- a/features/recently-viewed-channels/hooks/useAddChannelToRecent.tsx
+++ b/features/recently-viewed-channels/hooks/useAddChannelToRecent.tsx
@@ -1,0 +1,11 @@
+import { useEffect } from "react";
+import { Channel } from "types/backendAPITypes";
+import { useRecentlyViewedChannels } from "./useRecentlyViewedChannels";
+
+export function useAddChannelToRecentOnMount(channel: Channel) {
+  const { addChannelToRecent } = useRecentlyViewedChannels();
+
+  useEffect(() => {
+    addChannelToRecent(channel);
+  }, [channel, addChannelToRecent]);
+}

--- a/features/recently-viewed-channels/hooks/useRecentlyViewedChannels.tsx
+++ b/features/recently-viewed-channels/hooks/useRecentlyViewedChannels.tsx
@@ -10,6 +10,7 @@ const MAX_RECENT_CHANNELS = 5;
 
 export function useRecentlyViewedChannels() {
   const [recentChannels, setRecentChannels] = useState<Channel[]>([]);
+  console.log(recentChannels);
 
   useEffect(() => {
     const storedChannels =
@@ -25,7 +26,18 @@ export function useRecentlyViewedChannels() {
           (_channel) => _channel.channel_id === channel.channel_id
         )
       ) {
-        return prevChannels;
+        // If the channel is already at the top, no need to change the state
+        if (prevChannels[0].channel_id === channel.channel_id) {
+          return prevChannels;
+        }
+
+        const remainingChannels = prevChannels.filter(
+          (_channel) => _channel.channel_id !== channel.channel_id
+        );
+        // Move the channel to the 'top' of the list
+        const updatedChannelList = [channel, ...remainingChannels];
+        saveToLocalStorage("recentChannels", updatedChannelList);
+        return [channel, ...remainingChannels];
       }
 
       const newChannels = [channel, ...prevChannels].slice(

--- a/features/recently-viewed-channels/hooks/useRecentlyViewedChannels.tsx
+++ b/features/recently-viewed-channels/hooks/useRecentlyViewedChannels.tsx
@@ -9,6 +9,15 @@ import {
 
 const MAX_RECENT_CHANNELS = 5;
 
+/**
+ * A hook to manage a user's recently viewed channels list. Utilizes local storage and is
+ * bounded to a maximum of 5 recent channels. Depends on a valid `userId`.
+ *
+ * @returns {object}
+ * - recentlyViewedChannels: array of recent channels
+ * - addChannelToRecent: function to add a channel to the recent list
+ * - clearRecentChannels: function to clear the recent channels list
+ */
 export function useRecentlyViewedChannels() {
   const userId = useUserId();
   const [recentChannels, setRecentChannels] = useState<Channel[]>([]);

--- a/features/recently-viewed-channels/hooks/useRecentlyViewedChannels.tsx
+++ b/features/recently-viewed-channels/hooks/useRecentlyViewedChannels.tsx
@@ -1,0 +1,50 @@
+import { useState, useEffect } from "react";
+import { Channel } from "types/backendAPITypes";
+import {
+  clearLocalStorage,
+  getFromLocalStorage,
+  saveToLocalStorage,
+} from "../utils/localStorage";
+
+const MAX_RECENT_CHANNELS = 5;
+
+export function useRecentlyViewedChannels() {
+  const [recentChannels, setRecentChannels] = useState<Channel[]>([]);
+
+  useEffect(() => {
+    const storedChannels =
+      getFromLocalStorage<Channel[]>("recentChannels") || [];
+    setRecentChannels(storedChannels);
+  }, []);
+
+  const addChannelToRecent = (channel: Channel) => {
+    setRecentChannels((prevChannels) => {
+      // Check if the channel is already in the list
+      if (
+        prevChannels.some(
+          (_channel) => _channel.channel_id === channel.channel_id
+        )
+      ) {
+        return prevChannels;
+      }
+
+      const newChannels = [channel, ...prevChannels].slice(
+        0,
+        MAX_RECENT_CHANNELS
+      );
+      saveToLocalStorage("recentChannels", newChannels);
+      return newChannels;
+    });
+  };
+
+  const clearRecentChannels = () => {
+    clearLocalStorage("recentChannels");
+    setRecentChannels([]);
+  };
+
+  return {
+    recentlyViewedChannels: recentChannels,
+    addChannelToRecent,
+    clearRecentChannels,
+  };
+}

--- a/features/recently-viewed-channels/hooks/useRecentlyViewedChannels.tsx
+++ b/features/recently-viewed-channels/hooks/useRecentlyViewedChannels.tsx
@@ -13,7 +13,7 @@ const MAX_RECENT_CHANNELS = 5;
  * A hook to manage a user's recently viewed channels list. Utilizes local storage and is
  * bounded to a maximum of 5 recent channels. Depends on a valid `userId`.
  *
- * @returns {object}
+ * @returns
  * - recentlyViewedChannels: array of recent channels
  * - addChannelToRecent: function to add a channel to the recent list
  * - clearRecentChannels: function to clear the recent channels list
@@ -59,10 +59,23 @@ export function useRecentlyViewedChannels() {
         return [channel, ...remainingChannels];
       }
 
-      const newChannels = [channel, ...prevChannels].slice(
-        0,
-        MAX_RECENT_CHANNELS
-      );
+      const newChannels = [channel, ...prevChannels];
+
+      // Get the count of the new channel's platform
+      const platformCount = newChannels.filter(
+        (ch) => ch.platform === channel.platform
+      ).length;
+      console.log(platformCount);
+
+      // If the count exceeds MAX_RECENT_CHANNELS, remove the oldest entry of that platform
+      if (platformCount > MAX_RECENT_CHANNELS) {
+        for (let i = newChannels.length - 1; i >= 0; i--) {
+          if (newChannels[i].platform === channel.platform) {
+            newChannels.splice(i, 1);
+            break;
+          }
+        }
+      }
       saveToLocalStorage(storageKey, newChannels);
       return newChannels;
     });

--- a/features/recently-viewed-channels/hooks/useRecentlyViewedChannels.tsx
+++ b/features/recently-viewed-channels/hooks/useRecentlyViewedChannels.tsx
@@ -1,3 +1,4 @@
+import { useUserId } from "features/auth/hooks/useUserId";
 import { useState, useEffect } from "react";
 import { Channel } from "types/backendAPITypes";
 import {
@@ -9,17 +10,26 @@ import {
 const MAX_RECENT_CHANNELS = 5;
 
 export function useRecentlyViewedChannels() {
+  const userId = useUserId();
   const [recentChannels, setRecentChannels] = useState<Channel[]>([]);
-  console.log(recentChannels);
 
   useEffect(() => {
-    const storedChannels =
-      getFromLocalStorage<Channel[]>("recentChannels") || [];
+    if (!userId) {
+      return;
+    }
+
+    const storageKey = `recentChannels-${userId}`;
+    const storedChannels = getFromLocalStorage<Channel[]>(storageKey) || [];
     setRecentChannels(storedChannels);
-  }, []);
+  }, [userId]);
 
   const addChannelToRecent = (channel: Channel) => {
+    if (!userId) {
+      return;
+    }
+
     setRecentChannels((prevChannels) => {
+      const storageKey = `recentChannels-${userId}`;
       // Check if the channel is already in the list
       if (
         prevChannels.some(
@@ -36,7 +46,7 @@ export function useRecentlyViewedChannels() {
         );
         // Move the channel to the 'top' of the list
         const updatedChannelList = [channel, ...remainingChannels];
-        saveToLocalStorage("recentChannels", updatedChannelList);
+        saveToLocalStorage(storageKey, updatedChannelList);
         return [channel, ...remainingChannels];
       }
 
@@ -44,13 +54,18 @@ export function useRecentlyViewedChannels() {
         0,
         MAX_RECENT_CHANNELS
       );
-      saveToLocalStorage("recentChannels", newChannels);
+      saveToLocalStorage(storageKey, newChannels);
       return newChannels;
     });
   };
 
   const clearRecentChannels = () => {
-    clearLocalStorage("recentChannels");
+    if (!userId) {
+      return;
+    }
+
+    const storageKey = `recentChannels-${userId}`;
+    clearLocalStorage(storageKey);
     setRecentChannels([]);
   };
 

--- a/features/recently-viewed-channels/index.ts
+++ b/features/recently-viewed-channels/index.ts
@@ -1,0 +1,2 @@
+export * from "./hooks/useAddChannelToRecent";
+export * from "./hooks/useRecentlyViewedChannels";

--- a/features/recently-viewed-channels/utils/localStorage.ts
+++ b/features/recently-viewed-channels/utils/localStorage.ts
@@ -1,0 +1,43 @@
+/**
+ * Save an item to local storage.
+ *
+ * @param key - The key under which the item should be stored.
+ * @param value - The value to store, which will be JSON.stringified before storage.
+ */
+export function saveToLocalStorage<T>(key: string, value: T): void {
+  try {
+    const serializedValue = JSON.stringify(value);
+    localStorage.setItem(key, serializedValue);
+  } catch (error) {
+    console.error("Failed to save to local storage", error);
+  }
+}
+
+/**
+ * Get an item from local storage.
+ *
+ * @param key - The key under which the item is stored.
+ * @returns The retrieved item, or null if the item does not exist or there was an error retrieving it.
+ */
+export function getFromLocalStorage<T>(key: string): T | null {
+  try {
+    const serializedValue = localStorage.getItem(key);
+    return serializedValue ? (JSON.parse(serializedValue) as T) : null;
+  } catch (error) {
+    console.error("Failed to get item from local storage", error);
+    return null;
+  }
+}
+
+/**
+ * Remove an item from local storage.
+ *
+ * @param key - The key of the item to remove.
+ */
+export function clearLocalStorage(key: string): void {
+  try {
+    localStorage.removeItem(key);
+  } catch (error) {
+    console.error("Failed to remove item from local storage", error);
+  }
+}

--- a/features/saved-channels/components/saved-channel-list/SidebarSavedChannelList.tsx
+++ b/features/saved-channels/components/saved-channel-list/SidebarSavedChannelList.tsx
@@ -53,7 +53,15 @@ export const SidebarSavedChannelsList = ({
       <TwitchNameIcon fill="#9147FF" className={styles.twitchHeader} />
       <div className={styles.savedChannelList} onClick={closeSidebar}>
         {twitchChannelIds.length > 0 ? (
-          <TwitchSavedChannelList channelIds={twitchChannelIds} />
+          // Sort alphabetically
+          <TwitchSavedChannelList
+            channelIds={twitchChannelIds}
+            sortFn={(a, b) =>
+              a.channelData.displayName
+                .toLowerCase()
+                .localeCompare(b.channelData.displayName.toLowerCase())
+            }
+          />
         ) : (
           <p className={styles.subheader}>No saved channels</p>
         )}
@@ -61,7 +69,15 @@ export const SidebarSavedChannelsList = ({
       <YouTubeFullIcon className={styles.youtubeHeader} />
       <div className={styles.savedChannelList} onClick={closeSidebar}>
         {youtubeChannelIds.length > 0 ? (
-          <YouTubeSavedChannelList channelIds={youtubeChannelIds} />
+          // Sort alphabetically
+          <YouTubeSavedChannelList
+            channelIds={youtubeChannelIds}
+            sortFn={(a, b) =>
+              a.snippet.title
+                .toLowerCase()
+                .localeCompare(b.snippet.title.toLowerCase())
+            }
+          />
         ) : (
           <p className={styles.subheader}>No saved channels</p>
         )}

--- a/features/saved-channels/components/saved-channel-list/TwitchSavedChannelList.tsx
+++ b/features/saved-channels/components/saved-channel-list/TwitchSavedChannelList.tsx
@@ -4,11 +4,14 @@ import { SavedChannelCard } from "./SavedChannelCard";
 import { toast } from "react-hot-toast";
 import styles from "../styles/SidebarSavedChannelList.module.css";
 import { LoadingSpinner } from "components/spinner";
+import { TwitchChannel } from "features/channels";
 
 export const TwitchSavedChannelList = ({
   channelIds,
+  sortFn,
 }: {
   channelIds: string[];
+  sortFn?: (a: TwitchChannel, b: TwitchChannel) => number;
 }) => {
   const {
     data: channels,
@@ -32,15 +35,15 @@ export const TwitchSavedChannelList = ({
     return null;
   }
 
-  const sortedChannels = channels.sort((a, b) =>
-    a.channelData.displayName
-      .toLowerCase()
-      .localeCompare(b.channelData.displayName.toLowerCase())
-  );
+  const channelsToRender = [...channels];
+
+  if (sortFn) {
+    channelsToRender.sort(sortFn);
+  }
 
   return (
     <div>
-      {sortedChannels.map((channel) => (
+      {channelsToRender.map((channel) => (
         <SavedChannelCard
           key={channel.channelData.id}
           thumbnailUrl={channel.userData.profilePictureUrl}

--- a/features/saved-channels/components/saved-channel-list/YouTubeSavedChannelList.tsx
+++ b/features/saved-channels/components/saved-channel-list/YouTubeSavedChannelList.tsx
@@ -4,11 +4,17 @@ import { toast } from "react-hot-toast";
 import styles from "../styles/SidebarSavedChannelList.module.css";
 import { LoadingSpinner } from "components/spinner";
 import { useGetYouTubeChannels } from "features/channels/hooks/useGetYouTubeChannels";
+import { YouTubeChannelSearchResult } from "types/youtubeAPITypes";
 
 export const YouTubeSavedChannelList = ({
   channelIds,
+  sortFn,
 }: {
   channelIds: string[];
+  sortFn?: (
+    a: YouTubeChannelSearchResult,
+    b: YouTubeChannelSearchResult
+  ) => number;
 }) => {
   const {
     data: channels,
@@ -32,13 +38,15 @@ export const YouTubeSavedChannelList = ({
     return null;
   }
 
-  const sortedChannels = channels.sort((a, b) =>
-    a.snippet.title.toLowerCase().localeCompare(b.snippet.title.toLowerCase())
-  );
+  const channelsToRender = [...channels];
+
+  if (sortFn) {
+    channelsToRender.sort(sortFn);
+  }
 
   return (
     <div>
-      {sortedChannels.map((channel) => (
+      {channelsToRender.map((channel) => (
         <SavedChannelCard
           key={channel.id}
           thumbnailUrl={channel.snippet.thumbnails.medium.url}

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.0.1.tgz",
-      "integrity": "sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
+      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
       "dev": true
     },
     "node_modules/@ampproject/remapping": {
@@ -149,9 +149,9 @@
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -200,9 +200,9 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -3998,9 +3998,9 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -4076,9 +4076,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -5237,9 +5237,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -7022,9 +7022,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -8226,9 +8226,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -8680,9 +8680,9 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
-      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
       "dependencies": {
         "psl": "^1.1.33",
@@ -9092,9 +9092,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -9215,9 +9215,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
-      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
+      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
       "dev": true,
       "engines": {
         "node": ">= 14"
@@ -9294,9 +9294,9 @@
   },
   "dependencies": {
     "@adobe/css-tools": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.0.1.tgz",
-      "integrity": "sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
+      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
       "dev": true
     },
     "@ampproject/remapping": {
@@ -9373,9 +9373,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -9413,9 +9413,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -12298,9 +12298,9 @@
           }
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -12348,9 +12348,9 @@
           }
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -13165,9 +13165,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -14509,9 +14509,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -15355,9 +15355,9 @@
       }
     },
     "semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -15681,9 +15681,9 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
     "tough-cookie": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
-      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
       "requires": {
         "psl": "^1.1.33",
@@ -15968,9 +15968,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
     "wrap-ansi": {
@@ -16055,9 +16055,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
-      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
+      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
       "dev": true
     },
     "yargs": {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,3 +1,4 @@
+import { RecentlyViewedChannels } from "features/recently-viewed-channels/components/RecentlyViewedChannels";
 import Head from "next/head";
 
 export default function Home() {
@@ -6,6 +7,7 @@ export default function Home() {
       <Head>
         <title>Resports</title>
       </Head>
+      <RecentlyViewedChannels />
     </>
   );
 }

--- a/pages/twitch/channel/[channelId].tsx
+++ b/pages/twitch/channel/[channelId].tsx
@@ -1,7 +1,7 @@
 import { sanitiseChannelQuery } from "utils/queryHandling";
 import { GetServerSideProps } from "next";
 import { TwitchChannelPage } from "features/channels";
-import { useAddChannelToRecentOnMount } from "features/recently-viewed-channels";
+import { useAddChannelToRecent } from "features/recently-viewed-channels";
 
 interface ChannelProps {
   channelId: string;
@@ -14,7 +14,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 };
 
 const Channel = ({ channelId }: ChannelProps) => {
-  useAddChannelToRecentOnMount({
+  useAddChannelToRecent({
     channel_id: channelId,
     platform: "twitch",
   });

--- a/pages/twitch/channel/[channelId].tsx
+++ b/pages/twitch/channel/[channelId].tsx
@@ -1,6 +1,7 @@
 import { sanitiseChannelQuery } from "utils/queryHandling";
 import { GetServerSideProps } from "next";
 import { TwitchChannelPage } from "features/channels";
+import { useAddChannelToRecentOnMount } from "features/recently-viewed-channels";
 
 interface ChannelProps {
   channelId: string;
@@ -12,8 +13,12 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   return { props: { channelId } };
 };
 
-const Channel = ({ channelId }: ChannelProps) => (
-  <TwitchChannelPage channelId={channelId} />
-);
+const Channel = ({ channelId }: ChannelProps) => {
+  useAddChannelToRecentOnMount({
+    channel_id: channelId,
+    platform: "twitch",
+  });
+  return <TwitchChannelPage channelId={channelId} />;
+};
 
 export default Channel;

--- a/pages/youtube/channel/[channelId].tsx
+++ b/pages/youtube/channel/[channelId].tsx
@@ -1,5 +1,5 @@
 import { YouTubeChannelPage } from "features/channels";
-import { useAddChannelToRecentOnMount } from "features/recently-viewed-channels";
+import { useAddChannelToRecent } from "features/recently-viewed-channels";
 import { GetServerSideProps } from "next";
 import { sanitiseChannelQuery } from "utils/queryHandling";
 
@@ -14,7 +14,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 };
 
 const Channel = ({ channelId }: ChannelProps) => {
-  useAddChannelToRecentOnMount({
+  useAddChannelToRecent({
     channel_id: channelId,
     platform: "youtube",
   });

--- a/pages/youtube/channel/[channelId].tsx
+++ b/pages/youtube/channel/[channelId].tsx
@@ -1,4 +1,5 @@
 import { YouTubeChannelPage } from "features/channels";
+import { useAddChannelToRecentOnMount } from "features/recently-viewed-channels";
 import { GetServerSideProps } from "next";
 import { sanitiseChannelQuery } from "utils/queryHandling";
 
@@ -12,8 +13,12 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   return { props: { channelId } };
 };
 
-const Channel = ({ channelId }: ChannelProps) => (
-  <YouTubeChannelPage channelId={channelId} />
-);
+const Channel = ({ channelId }: ChannelProps) => {
+  useAddChannelToRecentOnMount({
+    channel_id: channelId,
+    platform: "youtube",
+  });
+  return <YouTubeChannelPage channelId={channelId} />;
+};
 
 export default Channel;


### PR DESCRIPTION
This PR adds the 'recently viewed channels' feature. This feature has the following:

- Saves the most recently viewed channels to local storage
- Channels are user specific, and for logged in users only
- Only the 5 most recent channels are saved for each platform
- Recently viewed channels are clearable
- The list will be sorted purely by most recently viewed